### PR TITLE
Fix: Change Automated release process to not use develop and RC's

### DIFF
--- a/.github/workflows/create_tag.yml
+++ b/.github/workflows/create_tag.yml
@@ -5,31 +5,28 @@ on:
     types: closed
 
 jobs:
-  develop:
-    name: Create RC
+  release:
+    name: Create Release
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged && github.base_ref == 'develop'
+    if: github.event.pull_request.merged && github.base_ref == 'master'
     steps:
       - name: Checkout Code
         uses: actions/checkout@master
         with:
-          ref: 'develop'
+          ref: 'master'
 
       - name: Create Tag
         uses: K-Phoen/semver-release-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          release_branch: develop
-          tag_format: v%major%.%minor%.%patch%-RC
+          release_branch: master
           release_strategy: tag
       
       - name: Create Release
         if: steps.create_tag.outputs.tag
         uses: Roang-zero1/github-create-release-action@master
         with:
-          created_tag: ${{ steps.tag_and_prepare_release.outputs.tag }}
-          version_regex: ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+
-          prerelease_regex: ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+-RC
+          created_tag: ${{ steps.create_tag.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Fixed** for any bug fixes.
 - **Security** in case of vulnerabilities.
 
-## [Unreleased]
+## [0.1.1] - 08/25/2020
+
+### Changed
+
+- Update the changelog 
+
+### Removed
+
+- Release Canidates from Release Process for now
+
+## [0.1.0-RC] - 08/25/2020
+
+### Added
+
+- Global Var to execute bash scripts
+- Automated Release Process with Github Actions
 
 ## [0.0.1] - 06/06/2020
 
@@ -22,7 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub workflow for unit testing
 - This changelog
 
-[unreleased]: https://github.com/DontShaveTheYak/jenkins-std-lib/compare/v0.0.1...develop
-
-[0.0.2]: https://github.com/DontShaveTheYak/jenkins-std-lib/compare/v0.0.1...v0.0.2
+[0.1.1]: https://github.com/DontShaveTheYak/jenkins-std-lib/compare/v0.1.0-RC...v0.1.1
+[0.1.0-RC]: https://github.com/DontShaveTheYak/jenkins-std-lib/compare/v0.0.1...v0.1.0-RC
 [0.0.1]: https://github.com/DontShaveTheYak/jenkins-std-lib/releases/tag/v0.0.1


### PR DESCRIPTION
Managing RC's and develop branch is too much of a pain for now. All PR's merged into master will be a proper release from now on. We can revisit master/develop and RC's in the future if needed. 

Also updated the changelog.