### PR TITLE
Add scm package

### DIFF
--- a/jobs/scm/generic_example.groovy
+++ b/jobs/scm/generic_example.groovy
@@ -1,0 +1,49 @@
+/* groovylint-disable DuplicateMapLiteral, DuplicateStringLiteral, UnusedVariable */
+@Library('jenkins-std-lib')
+
+import org.dsty.scm.Generic
+
+node() {
+    String cps = sh(script: '#!/bin/bash\nset +x; > /dev/null 2>&1\necho Test for CPS issue', returnStdout: true)
+
+    // If you are not sure if you are dealing with git or svn then Generic is a good choice.
+    Generic scmClient = new Generic(this)
+
+    // These are the same options you would pass to the checkout step
+    // https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step/
+
+    String defaultBranch = 'master'
+
+    Map options = [
+        changelog: false,
+        poll: false,
+        scm: [
+            $class: 'GitSCM',
+            branches: [[name: defaultBranch]],
+            extensions: [],
+            userRemoteConfigs: [[url: 'https://github.com/DontShaveTheYak/jenkins-std-lib.git']]
+        ]
+    ]
+
+    scmClient.checkout(options)
+
+    if (!env.GIT_BRANCH.contains(defaultBranch)) {
+        error("${env.GIT_BRANCH} should be equal to ${defaultBranch}.")
+    }
+
+    options.scm.branches = [[name: 'develop']]
+
+    dir('testing') {
+        scmClient.withCheckout(options) {
+            if (env.GIT_BRANCH.contains(defaultBranch)) {
+                error("${env.GIT_BRANCH} should not equal ${defaultBranch}.")
+            }
+        }
+    }
+
+    if (!env.GIT_BRANCH.contains(defaultBranch)) {
+        error("${env.GIT_BRANCH} should be equal to ${defaultBranch}.")
+    }
+
+    cps = sh(script: '#!/bin/bash\nset +x; > /dev/null 2>&1\necho Test for CPS issue', returnStdout: true)
+}

--- a/jobs/scm/git_example.groovy
+++ b/jobs/scm/git_example.groovy
@@ -1,0 +1,87 @@
+/* groovylint-disable DuplicateMapLiteral, DuplicateStringLiteral, UnnecessaryGetter, UnusedVariable */
+@Library('jenkins-std-lib')
+
+import org.dsty.scm.Git
+
+node() {
+    String cps = sh(script: '#!/bin/bash\nset +x; > /dev/null 2>&1\necho Test for CPS issue', returnStdout: true)
+
+    // When you know you are using Git.
+    Git git = new Git(this)
+
+    // These are the same options you would pass to the checkout step
+    // https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step/
+
+    git.checkout(
+        changelog: false,
+        poll: false,
+        scm: [
+            $class: 'GitSCM',
+            branches: [[name: '0.7.0']],
+            extensions: [],
+            userRemoteConfigs: [[url: 'https://github.com/DontShaveTheYak/jenkins-std-lib.git']]
+        ]
+    )
+
+    Map envVars = getEnvVars()
+
+    Map gitVars = envVars.findAll { k, v ->
+        k.contains('GIT')
+    }
+
+    if (gitVars.size() < 3) {
+        // The number will depend on the plugins you have.
+        // It should at least set GIT_COMMIT, GIT_BRANCH and GIT_URL
+        error('Should set GIT_* Environment variables.')
+    }
+
+    git.changeBranch('0.6.3')
+
+    if (env.GIT_BRANCH != '0.6.3') {
+        error('Should update Environment variables when changing branches.')
+    }
+
+    git.withBranch('master') {
+        if (env.GIT_BRANCH != 'master') {
+            error('Should update Environment variables when temporaily changing branch.')
+        }
+    }
+
+    List<String> updatedFiles = git.changedFiles(target:'0.7.0')
+
+    if (updatedFiles.size() != 27) {
+        error('Should return the files that changed.')
+    }
+
+    List<String> localBranches = git.localBranches()
+
+    if (!localBranches.contains('master')) {
+        error('Should have the master branch locally.')
+    }
+
+    List<String> remoteBranches = git.remoteBranches()
+
+    if (!remoteBranches.contains('origin/develop')) {
+        error('Should have the develop branch on the remote.')
+    }
+
+    List<String> tags = git.tags()
+
+    if (!tags.contains('0.2.1')) {
+        error('Should have the tag 0.2.1.')
+    }
+
+    cps = sh(script: '#!/bin/bash\nset +x; > /dev/null 2>&1\necho Test for CPS issue', returnStdout: true)
+}
+
+Map getEnvVars() {
+    String result = sh(script: 'printenv | paste -sd "," -', returnStdout: true).trim()
+    List<String> vars = result.split(',')
+
+    Map envVars = vars.collectEntries { String envVar ->
+        List parts = envVar.split('=')
+        [(parts[0]): parts[1]]
+    }
+
+    return envVars
+}

--- a/jobs/scm/tests/test_generic.groovy
+++ b/jobs/scm/tests/test_generic.groovy
@@ -1,0 +1,38 @@
+/* groovylint-disable DuplicateMapLiteral, DuplicateStringLiteral, UnusedVariable */
+@Library('jenkins-std-lib')
+
+import org.dsty.scm.Generic
+
+node() {
+    String cps = sh(script: '#!/bin/bash\nset +x; > /dev/null 2>&1\necho Test for CPS issue', returnStdout: true)
+
+    Generic scmClient = new Generic(this)
+
+    Map newEnvVars = ['KeyA': 'ValueA']
+
+    scmClient.saveEnvironment(newEnvVars)
+
+
+    Map currentVars = getEnvVars()
+
+    newEnvVars.each { k, v ->
+        if (!currentVars.containsKey(k) || !currentVars.containsValue(v)) {
+            error("${k} or ${v} missing from environment variables.")
+        }
+    }
+
+
+    cps = sh(script: '#!/bin/bash\nset +x; > /dev/null 2>&1\necho Test for CPS issue', returnStdout: true)
+}
+
+Map getEnvVars() {
+    String result = sh(script: 'printenv | paste -sd "," -', returnStdout: true).trim()
+    List<String> vars = result.split(',')
+
+    Map envVars = vars.collectEntries { String envVar ->
+        List parts = envVar.split('=')
+        [(parts[0]): parts[1]]
+    }
+
+    return envVars
+}

--- a/src/org/dsty/scm/Generic.groovy
+++ b/src/org/dsty/scm/Generic.groovy
@@ -1,0 +1,123 @@
+package org.dsty.scm
+
+import org.dsty.logging.LogClient
+
+/**
+ * Generic SCM client capable of checkingout code.
+ */
+class Generic implements Serializable {
+
+    /**
+     * Workflow script representing the jenkins build.
+     */
+    protected final Object steps
+
+    /**
+     * Logging client
+     */
+    protected final LogClient log
+
+    /**
+     * Default Constructor
+     * <pre>{@code
+     * import org.dsty.scm.Generic
+     *node() {
+     *  Generic scmClient = new Generic(this)
+     *  Map options = [
+     *      changelog: false,
+     *      poll: false,
+     *      scm: [
+     *          $class: 'GitSCM',
+     *          branches: [[name: 'master']],
+     *          extensions: [],
+     *          userRemoteConfigs: [[url: 'https://github.com/cplee/github-actions-demo.git']]
+     *      ]
+     *  ]
+     *  scmClient.checkout(options)
+     *&#125;}</pre>
+     * @param steps The workflow script representing the jenkins build.
+     */
+    Generic(Object steps) {
+        this.steps = steps
+        this.log = new LogClient(steps)
+    }
+
+    /**
+     * Behaves like the native Jenkins checkout step but this one
+     * saves the GIT_* envioronment variables correctly.
+     * @param options The valid keys and values can be found
+     * <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step/">here</a>.
+     * @return The outputs from the checkout.
+     */
+    Map checkout(Map options) {
+        Map results
+
+        results = this.executeCheckout(options)
+
+        this.saveEnvironment(results)
+
+        return results
+    }
+
+    /**
+     * Same as {@link #checkout()} but for MultiBranch pipelines.
+     * @param options The valid keys and values can be found
+     * <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step/">here</a>.
+     * @return The outputs from the checkout.
+     */
+    Map checkoutMultiBranch() {
+        Map results
+
+        results = this.executeCheckout(this.steps.scm)
+
+        this.saveEnvironment(results)
+
+        return results
+    }
+
+    /**
+     * Same as {@link #checkout()} but this will restore the original GIT_*
+     * environment variables before it returns.
+     * @param options The valid keys and values can be found
+     * <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step/">here</a>.
+     * @param userCode the steps you want to take while the code is checked out.
+     * @return The outputs from the checkout.
+     */
+    Map withCheckout(Map options, Closure userCode) {
+        Map results
+
+        results = this.executeCheckout(options)
+
+        List envVars = results.collect { k, v ->
+            "${k}=${v}"
+        }
+
+        this.steps.withEnv(envVars) {
+            userCode()
+        }
+
+        return results
+    }
+
+    /**
+     * Runs the native Jenkins checkout step.
+     * @param options The valid keys and values can be found
+     * <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-scm-step/">here</a>.
+     * @return The outputs from the checkout.
+     */
+    protected Map executeCheckout(Object options) {
+        Map results = this.steps.checkout(options)
+
+        this.log.debug("Checkout information:\n${this.log.pprint(results)}")
+        return results
+    }
+
+    /**
+     * Save the outputs from the checkout step as environment variables.
+     * @param envVars The values you want to save as environment variables.
+     */
+    protected void saveEnvironment(Map envVars) {
+        envVars.each { k, v -> this.steps.env.setProperty(k, v) }
+    }
+
+}

--- a/src/org/dsty/scm/Git.groovy
+++ b/src/org/dsty/scm/Git.groovy
@@ -1,0 +1,148 @@
+/* groovylint-disable CatchException, DuplicateMapLiteral, DuplicateStringLiteral, ThrowException */
+package org.dsty.scm
+
+import org.dsty.bash.Result
+import org.dsty.bash.BashClient
+import org.dsty.bash.ScriptError
+
+/**
+ * Git client for interacting with Git repositories.
+ */
+class Git extends Generic implements Serializable {
+
+    /**
+     * Bash client
+     */
+    private final BashClient bash
+
+    /**
+     * Default Constructor
+     * <pre>{@code
+     * import org.dsty.scm.Git
+     *node() {
+     *  Git gitClient = new Git(this)
+     *  Map options = [
+     *      changelog: false,
+     *      poll: false,
+     *      scm: [
+     *          $class: 'GitSCM',
+     *          branches: [[name: 'master']],
+     *          extensions: [],
+     *          userRemoteConfigs: [[url: 'https://github.com/cplee/github-actions-demo.git']]
+     *      ]
+     *  ]
+     *  gitClient.checkout(options)
+     *&#125;}</pre>
+     * @param steps The workflow script representing the jenkins build.
+     */
+    Git(Object steps) {
+        super(steps)
+        this.bash = new BashClient(steps)
+    }
+
+    /**
+     * Change to a branch in the current repo.
+     * @param branchName The name of the git branch.
+     */
+    void changeBranch(String branchName) {
+        this.executeGit("checkout ${branchName}")
+        this.steps.env.GIT_BRANCH = branchName
+    }
+
+    /**
+     * Same as {@link #changeBranch()} but this will restore the original
+     * branch before it returns.
+     * @param branchName The name of the git branch.
+     * @param userCode the steps you want to take while the branch is checked out.
+     */
+    void withBranch(String branchName, Closure userCode) {
+        String previousBranch = this.steps.env.GIT_BRANCH
+
+        this.changeBranch(branchName)
+
+        try {
+            userCode()
+        } catch (Exception ex) {
+            this.changeBranch(previousBranch)
+            throw ex
+        }
+
+        this.changeBranch(previousBranch)
+    }
+
+    /**
+     * Get a list of branch names that are avaliable locally.
+     * @return The name of the branches.
+     */
+    List<String> localBranches() {
+        Result result = this.executeGit('for-each-ref refs/heads --format "%(refname:strip=2)" | paste -sd "," -')
+
+        List<String> branches = result.stdOut.trim().split(',')
+        return branches
+    }
+
+
+    /**
+     * Get a list of branch names that are avaliable on the remote.
+     * @return The name of the branches.
+     */
+    List<String> remoteBranches() {
+        Result result = this.executeGit('branch -r | cut -c 3- | paste -sd "," -')
+
+        List<String> branches = result.stdOut.trim().split(',')
+        return branches
+    }
+
+    /**
+     * Get a list of all tags.
+     * @return The name of the tags.
+     */
+    List<String> tags() {
+        Result result = this.executeGit('tag | paste -sd "," -')
+
+        List<String> branches = result.stdOut.trim().split(',')
+        return branches
+    }
+
+    /**
+     * Execute a git command.
+     * @param args The options to pass to git.
+     * @return The result of the command.
+     */
+    List<String> changedFiles(Map<String,String> options) {
+        if (!options.target) {
+            this.log.error('You must specify a target revision to compare to.')
+            throw new Exception('No target supplied.')
+        }
+
+        String branchSource = options.source ?: 'HEAD'
+        String branchTarget = options.target
+        String filter = options.filter ? "--diff-filter=${options.filter}" : ''
+
+        Result result = this.executeGit("diff --name-only ${filter} ${branchSource} ${branchTarget} | paste -sd ',' -")
+
+        List<String> files = result.stdOut.trim().split(',')
+
+        return files
+    }
+
+    /**
+     * Execute a git command.
+     * @param args The options to pass to git.
+     * @return The result of the command.
+     */
+    private Result executeGit(String args) {
+        Result result
+
+        // This passes because of Pipe Fail!
+        try {
+            result = this.bash.silent("git ${args}")
+        } catch (ScriptError ex) {
+            this.log.debug(ex)
+            throw new Exception(ex.stdErr)
+        }
+
+        return result
+    }
+
+}

--- a/tests/test_scm/test_Generic.py
+++ b/tests/test_scm/test_Generic.py
@@ -1,0 +1,18 @@
+import pytest
+
+from tests.conftest import Container
+
+@pytest.fixture()
+def job_folder():
+    return 'scm'
+
+def test_generic_unit(container: Container, job_folder):
+
+    container(f"{job_folder}/tests/test_generic.groovy")
+
+def test_generic_example(container: Container, job_folder):
+
+    job_output = container(f"{job_folder}/generic_example.groovy")
+
+    assert "origin/master" in job_output
+    assert "origin/develop" in job_output

--- a/tests/test_scm/test_Git.py
+++ b/tests/test_scm/test_Git.py
@@ -1,0 +1,11 @@
+import pytest
+
+from tests.conftest import Container
+
+@pytest.fixture()
+def job_folder():
+    return 'scm'
+
+def test_git_example(container: Container, job_folder):
+
+    container(f"{job_folder}/git_example.groovy")


### PR DESCRIPTION
This init commit of the `scm` package provides some basic functionality, mainly around `git`.  The big improvement is now  when you checkout code the proper environment variables are set. 

New features:
* git.localBranches() - Return `List` of branch names available locally.
* git.remoteBranches() - Return `List` of branch names available remotely.
* git.tags() - Return `List` of all tags.
* git.changedFiles(target: 'develop') - Return `List` of changed files from the current branch to the `target` branch.
* git.changeBranch('develop') - Change to a different branch.
* git.withBranch('develop') { } - Temporarily switch to a branch and run the code inside `{ }`

See the example [job](https://github.com/DontShaveTheYak/jenkins-std-lib/blob/b06359bef40ffa412314d58dbce617142fc53ced/jobs/scm/git_example.groovy)