### PR TITLE
Add methods to return common directories to the Path class

### DIFF
--- a/jobs/os/path/path_example.groovy
+++ b/jobs/os/path/path_example.groovy
@@ -4,7 +4,8 @@ import org.dsty.os.Path
 
 node() {
 
-    Path workspace = new Path(env.WORKSPACE)
+    // Get a path to the current workspace.
+    Path workspace = Path.workspace()
 
     println("Workspace Path is ${workspace}")
 
@@ -51,6 +52,19 @@ node() {
         // Lets verify all of our directories were deleted
         if (dirA.exists() || dirB.exists() || dirB2.exists()) {
             error('Should have deleted all directories.')
+        }
+
+        String someDir = "${workspace}/someDir"
+
+        dir(someDir) {
+
+            // Get a Path to the current working directory
+            Path cwd = Path.cwd()
+
+            // Verify cwd is the directory we are in.
+            if (cwd != someDir) {
+                error("Should be in ${someDir} but acutally in ${cwd}")
+            }
         }
 
     }

--- a/src/org/dsty/os/Path.groovy
+++ b/src/org/dsty/os/Path.groovy
@@ -28,6 +28,11 @@ class Path implements Serializable {
     private final FilePath fp
 
     /**
+     * Internal {@link Build} object.
+     */
+    final static private Build BUILD = new Build()
+
+    /**
      * Creates a Path from a String reprensentation.
      *
      * @param path An absolute path on the system. The path doesn't have to exist yet.
@@ -655,8 +660,7 @@ class Path implements Serializable {
      * @return A {@link Path} to the current working directory.
      */
     static Path cwd() {
-        final Build build = new Build()
-        FilePath cwd = build.getCurrentContext(FilePath.class)
+        FilePath cwd = BUILD.getCurrentContext(FilePath.class)
 
         return new Path(cwd)
     }
@@ -668,8 +672,7 @@ class Path implements Serializable {
      * @return A {@link Path} to the current users home.
      */
     static Path userHome() {
-        final Build build = new Build()
-        Map<String, String> envVars = build.environmentVars()
+        Map<String, String> envVars = BUILD.environmentVars()
 
         return new Path(envVars.HOME)
     }
@@ -680,8 +683,7 @@ class Path implements Serializable {
      * @return A {@link Path} to the Jenkins home directory.
      */
     static Path jenkinsHome() {
-        final Build build = new Build()
-        Map<String, String> envVars = build.environmentVars()
+        Map<String, String> envVars = BUILD.environmentVars()
 
         return new Path(envVars.JENKINS_HOME)
     }

--- a/src/org/dsty/os/Path.groovy
+++ b/src/org/dsty/os/Path.groovy
@@ -252,7 +252,7 @@ class Path implements Serializable {
     @Override
     @NonCPS
     boolean equals(Object otherPath) {
-        return otherPath == this.fp
+        return otherPath.toString() == this.toString()
     }
 
     /**
@@ -559,7 +559,7 @@ class Path implements Serializable {
     @Override
     @NonCPS
     String toString() {
-        return fp
+        return fp.getRemote()
     }
 
     /**

--- a/src/org/dsty/os/Path.groovy
+++ b/src/org/dsty/os/Path.groovy
@@ -6,21 +6,31 @@ import java.util.Date
 import hudson.util.io.ArchiverFactory
 import com.cloudbees.groovy.cps.NonCPS
 
+import org.dsty.jenkins.Build
+
 /**
- * A wrapper around hudson.FilePath that allows easy file operations
- * with out resorting to shell.
+ * A wrapper around {@link hudson.FilePath} that allows easy file operations
+ * with out resorting to a shell like <code>sh()</code> or <code>bat()</code>.
+ * <p>
+ * A nice starting point is to get the {@link Path} to your jobs workspace using
+ * <a href="Path.html#workspace()">Path.workspace()</a>. You can also get
+ * the {@link Path} to the current users home directory using
+ * <a href="Path.html#userHome()">Path.userHome()</a> or
+ * <a href="Path.html#jenkinsHome()">Path.jenkinsHome()</a>. You can obtain a
+ * {@link Path} to the current working directory with
+ * <a href="Path.html#cwd()">Path.cwd()</a>.
  */
 class Path implements Serializable {
 
     /**
-     * Jenkins FilePath object
+     * Internal {@link FilePath} object.
      */
     private final FilePath fp
 
     /**
      * Creates a Path from a String reprensentation.
      *
-     * @param path A path on the system. The path doesn't have to exist yet.
+     * @param path An absolute path on the system. The path doesn't have to exist yet.
      */
     Path(String path) {
         this.fp = new FilePath(null, path)
@@ -619,6 +629,61 @@ class Path implements Serializable {
      */
     void write(String content, String encoding = null) {
         fp.write(content, encoding)
+    }
+
+    /**
+     * Get the path to the current builds workspace.
+     *
+     * @return A {@link Path} to the current builds workspace.
+     */
+    static Path workspace() {
+
+        final Build build = new Build()
+        Map<String, String> envVars = build.environmentVars()
+
+        return new Path(envVars.WORKSPACE)
+    }
+
+    /**
+     * Get the path to the current working directory. This is the same
+     * as the <code>pwd()</code> step.
+     * <p>
+     * This method is useful for when you might be inside of
+     * a <code>dir('someDir') {}</code> block and need to get
+     * the path to it.
+     *
+     * @return A {@link Path} to the current working directory.
+     */
+    static Path cwd() {
+        final Build build = new Build()
+        FilePath cwd = build.getCurrentContext(FilePath.class)
+
+        return new Path(cwd)
+    }
+
+    /**
+     * Get the path to the current users home. This is the same
+     * as <code>~<code> on unix systems.
+     *
+     * @return A {@link Path} to the current users home.
+     */
+    static Path userHome() {
+        final Build build = new Build()
+        Map<String, String> envVars = build.environmentVars()
+
+        return new Path(envVars.HOME)
+    }
+
+    /**
+     * Get the path to the Jenkins home directory.
+     *
+     * @return A {@link Path} to the Jenkins home directory.
+     */
+    static Path jenkinsHome() {
+        final Build build = new Build()
+        Map<String, String> envVars = build.environmentVars()
+
+        return new Path(envVars.JENKINS_HOME)
     }
 
 }

--- a/src/org/dsty/os/package-info.groovy
+++ b/src/org/dsty/os/package-info.groovy
@@ -1,5 +1,6 @@
 /**
- * This package provides operating system independent functionality. If you want to manipulate paths,
- * see the Path class.
+ * This package provides operating system independent functionality.
+ * <p>
+ * If you want to work with files/directories see <a href="Path.html">Path</a>.
  */
 package org.dsty.os

--- a/tests/test_jenkins/test_Build.py
+++ b/tests/test_jenkins/test_Build.py
@@ -1,0 +1,5 @@
+from tests.conftest import Container
+
+def test_build(container: Container):
+
+    container('jenkins/build_example.groovy')


### PR DESCRIPTION
Path class now has static methods to return some of the more common directories.

```groovy
Path workspace = Path.workspace()

Path homeDir = Path.userHome()

Path jenkinsHome = Path.jenkinsHome()
```