### PR TITLE
Move bash package to system.os.shell

### DIFF
--- a/src/org/dsty/bash/BashClient.groovy
+++ b/src/org/dsty/bash/BashClient.groovy
@@ -4,7 +4,9 @@ import org.dsty.logging.LogClient
 
 /**
  * Bash Client
+ * @deprecated As of release 0.10.0, replaced by {@link org.dsty.system.os.shell.Bash org.dsty.system.os.shell.Bash}
  */
+@Deprecated
 class BashClient implements Serializable {
 
     /**

--- a/src/org/dsty/bash/Result.groovy
+++ b/src/org/dsty/bash/Result.groovy
@@ -4,7 +4,9 @@ import com.cloudbees.groovy.cps.NonCPS
 
 /**
  * Contains the results of a bash script execution.
+ * @deprecated As of release 0.10.0, replaced by {@link org.dsty.system.os.shell.Result org.dsty.system.os.shell.Result}
  */
+@Deprecated
 class Result implements Serializable {
 
     /**

--- a/src/org/dsty/bash/ScriptError.groovy
+++ b/src/org/dsty/bash/ScriptError.groovy
@@ -2,7 +2,10 @@ package org.dsty.bash
 
 /**
  * Custom Exception thrown by the bash global variable.
+ * @deprecated As of release 0.10.0, replaced by
+ *             {@link org.dsty.system.os.shell.ExecutionException org.dsty.system.os.shell.ExecutionException}
  */
+@Deprecated
 class ScriptError extends Exception {
 
     /**

--- a/src/org/dsty/bash/package-info.groovy
+++ b/src/org/dsty/bash/package-info.groovy
@@ -1,4 +1,7 @@
 /**
  * Bash wrapper and helper utilities.
+ * @deprecated  As of release 0.10.0, replaced by
+ *              <a href="../system/os/shell/package-summary.html">org.dsty.system.os.shell</a>.
  */
+@Deprecated
 package org.dsty.bash

--- a/src/org/dsty/system/os/shell/Bash.groovy
+++ b/src/org/dsty/system/os/shell/Bash.groovy
@@ -1,0 +1,182 @@
+/* groovylint-disable UnnecessaryGetter */
+package org.dsty.system.os.shell
+
+import org.dsty.logging.LogClient
+import org.dsty.jenkins.Build
+import org.dsty.system.os.Path
+
+/**
+ * A {@link Shell} for executing commands on <code>UNIX</code>
+ * using the <code>Bash</code> executable.
+ * <p>
+ * The underlying implementation is actually the Jenkins
+ * <a href="https://www.jenkins.io/doc/pipeline/steps/workflow-durable-task-step/#sh-shell-script"
+ * target="_blank">sh()</a> step.
+ */
+class Bash implements Shell {
+
+    /**
+     * If <code>true</code> then the script is stopped on first non-zero exit code.
+     */
+    Boolean failFast = true
+
+    /**
+     * Workflow script representing the jenkins build.
+     */
+    private Object wfs
+
+    /**
+     * Logging client
+     */
+    private LogClient log
+
+
+
+    /**
+     * Formats a bash script by adding the shebang, setting the verbose level and sourcing bashrc.
+     *
+     * @param userScript  The bash script you want to run.
+     * @param silent      If <code>true</code> the results of the execution will not
+     *                    be shown in the Jenkins build console/log.
+     * @return            A bash script that is ready to be executed.
+     */
+    String formatScript(final String userScript, final Boolean silent=false) {
+        final String showOutput = 'exec 2> >(tee -a stderr stdall) 1> >(tee -a stdout stdall)'
+        final String hideOutput = 'exec 3>/dev/null 2> >(tee -a stderr stdall >&3) 1> >(tee -a stdout stdall >&3)'
+        final String exec = silent ? hideOutput : showOutput
+        final String setE = this.failFast ? 'set -e;' : 'set +e;'
+        final String setX = this.wfs.env.PIPELINE_LOG_LEVEL == 'DEBUG' ? 'set -x;' : 'set +x;'
+
+        final String header = """\
+            #!/bin/bash
+            source \$HOME/.bashrc > /dev/null 2>&1 || true
+            { ${setE} } > /dev/null 2>&1
+            ${exec}
+            { ${setX} } > /dev/null 2>&1
+
+            # User Script
+        """.stripIndent()
+
+        final String script = "${header}\n${userScript.stripIndent()}"
+        this.log.debug("Formatted script:\n${script}")
+
+        return script
+    }
+
+    /**
+     * Execute the command or script using <code>bash</code>.
+     *
+     * @param userScript  The bash command or script you want to execute.
+     * @param silent      If <code>true</code> the results of the execution will not
+     *                    be shown in the Jenkins build console/log.
+     * @return            A {@link Result} that contains the execution details.
+     * @throws            If an error occurs during the cmd execution a {@link ExecutionException} is thrown.
+     */
+    Result call(final String userScript) throws ExecutionException {
+        final String script = formatScript(userScript, false)
+
+        return execute(script)
+    }
+
+    /**
+     * Execute the command or script using <code>bash</code> but do not display any
+     * output to the Jenkins build console/log.
+     *
+     * @param userScript  The bash command or script you want to execute.
+     * @param silent      If <code>true</code> the results of the execution will not
+     *                    be shown in the Jenkins build console/log.
+     * @return            A {@link Result} that contains the execution details.
+     * @throws            If an error occurs during the cmd execution a {@link ExecutionException} is thrown.
+     */
+    Result silent(final String userScript) throws ExecutionException {
+        final String script = formatScript(userScript, true)
+
+        return execute(script)
+    }
+
+    /**
+     * Executes the command or script but does not throw a {@link ExecutionException} if an error
+     * occurs. Instead a {@link Result} object is returned with the details of the error.
+     *
+     * @param userScript  The bash command or script you want to execute.
+     * @param silent      If <code>true</code> the results of the execution will not
+     *                    be shown in the Jenkins build console/log.
+     * @return            A {@link Result} that contains the execution details.
+     */
+    Result ignoreErrors(String userScript, Boolean silent=false) {
+        String script = formatScript(userScript, silent)
+        Result result
+
+        try {
+            result = execute(script)
+        } catch (ExecutionException ex) {
+            result = new Result(ex.stdOut, ex.stdErr, ex.output, ex.exitCode)
+        }
+
+        return result
+    }
+
+    /**
+     * Executes the script using the Jenkins <code>sh()</code> step.
+     *
+     * @param script  The bash command or script you want to run.
+     * @return        The results of the bash command or script.
+     * @throws        If an error occurs during the cmd execution a {@link ExecutionException} is thrown.
+     */
+    private Result execute(String script) throws ExecutionException {
+        final Integer exitCode = this.wfs.sh(script: script, returnStatus: true)
+
+        def(String stdOut, String stdErr, String output) = readOutputs()
+
+        if (exitCode) {
+            throw new ExecutionException(stdOut, stdErr, output, exitCode)
+        }
+
+        return new Result(stdOut, stdErr, output, exitCode)
+    }
+
+    /**
+     * Reads the script outputs from files and then removes them.
+     * @return The stdout, stderr and combined script output.
+     */
+    private List<String> readOutputs() {
+
+        final List<String> fileNames = ['stdout', 'stderr', 'stdall']
+
+        final Path cwd = Path.cwd()
+
+        final List<Path> files = fileNames.collect { String fileName ->
+            cwd.child(fileName)
+        }
+
+        final List<String> outputs = files.collect { Path filePath ->
+            filePath.read().replaceAll('(?m)^\\+.*(?:\r?\n)?', '').trim()
+        }
+
+        files.each { Path filePath ->
+            filePath.delete()
+        }
+
+        return outputs
+    }
+
+    private Object getWfs() {
+        setWfs()
+        return this.@wfs
+    }
+
+    private void setWfs() {
+        Build build = new Build()
+        this.wfs = build.getWorkFlowScript()
+    }
+
+    private Object getLog() {
+        setLog()
+        return this.@log
+    }
+
+    private void setLog() {
+        this.log = new LogClient(this.wfs)
+    }
+
+}

--- a/src/org/dsty/system/os/shell/ExecutionException.groovy
+++ b/src/org/dsty/system/os/shell/ExecutionException.groovy
@@ -1,0 +1,52 @@
+package org.dsty.system.os.shell
+
+/**
+ * Exception thrown when a {@link Shell} command results in an error.
+ */
+class ExecutionException extends Exception {
+
+    /**
+     * The contents of stdOut from the command execution.
+     */
+    String stdOut
+
+    /**
+     * The contents of stdErr from the command execution.
+     */
+    String stdErr
+
+    /**
+     * The combined contents of stdOut and stdErr from the command execution.
+     */
+    String output
+
+    /**
+     * The exitCode from the command execution.
+     */
+    Integer exitCode
+
+    ExecutionException(String stdOut, String stdErr, String output, Integer exitCode) {
+        super("Script exitCode was ${exitCode} and stderr:\n${stdErr}")
+        this.stdOut = stdOut
+        this.stdErr = stdErr
+        this.output = output
+        this.exitCode = exitCode
+    }
+
+    ExecutionException(String stdOut, String stdErr, String output, Integer exitCode, Throwable cause) {
+        super("Script exitCode was ${exitCode} and stderr:\n${stdErr}", cause)
+        this.stdOut = stdOut
+        this.stdErr = stdErr
+        this.output = output
+        this.exitCode = exitCode
+    }
+
+    /**
+     * Similar to printing the exception but shows the command output
+     * instead of just the <code>stdErr</code>.
+     */
+    String getFullMessage() {
+        return "Script exitCode was ${this.exitCode}. Output was:\n${this.output}"
+    }
+
+}

--- a/src/org/dsty/system/os/shell/Result.groovy
+++ b/src/org/dsty/system/os/shell/Result.groovy
@@ -1,0 +1,47 @@
+package org.dsty.system.os.shell
+
+import com.cloudbees.groovy.cps.NonCPS
+
+/**
+ * Contains the results of a {@link Shell} command execution.
+ */
+class Result implements Serializable {
+
+    /**
+     * The contents of stdOut from the command execution.
+     */
+    String stdOut
+
+    /**
+     * The contents of stdErr from the command execution.
+     */
+    String stdErr
+
+    /**
+     * The combined contents of stdOut and stdErr from the command execution.
+     */
+    String output
+
+    /**
+     * The exitCode from the command execution.
+     */
+    Integer exitCode
+
+    Result(String stdOut, String stdErr, String output, Integer exitCode) {
+        this.stdOut = stdOut
+        this.stdErr = stdErr
+        this.output = output
+        this.exitCode = exitCode
+    }
+
+    /**
+     * Print the output of the command execution when the {@link Result} is printed.
+     * @return The output from the command execution.
+     */
+    @Override
+    @NonCPS
+    String toString() {
+        return this.output
+    }
+
+}

--- a/src/org/dsty/system/os/shell/Shell.groovy
+++ b/src/org/dsty/system/os/shell/Shell.groovy
@@ -1,0 +1,42 @@
+package org.dsty.system.os.shell
+
+/**
+ * A shell is capable of running commands with a variety
+ * of behaviors. It also handles input/output and generic
+ * error handling for the user.
+ */
+interface Shell extends Serializable {
+
+    /**
+     * Execute the cmd.
+     *
+     * @param cmd     The full command and arguments you want the <code>Shell</code>
+     *                to execute.
+     * @return        A {@link Result} that contains the execution details.
+     * @throws        If an error occurs during the cmd execution a {@link ExecutionException} is thrown.
+     */
+    Result call(String cmd) throws ExecutionException
+
+    /**
+     * Execute the cmd but do not display any output to the Jenkins build console/log.
+     *
+     * @param cmd     The full command and arguments you want the <code>Shell</code>
+     *                to execute.
+     * @return        A {@link Result} that contains the execution details.
+     * @throws        If an error occurs during the cmd execution a {@link ExecutionException} is thrown.
+     */
+    Result silent(String cmd) throws ExecutionException
+
+    /**
+     * Executes the cmd but does not throw a {@link ExecutionException} if an error
+     * occurs. Instead a {@link Result} object is returned with the details of the error.
+     *
+     * @param cmd     The full command and arguments you want the <code>Shell</code>
+     *                to execute.
+     * @param silent  If <code>true</code> the results of the execution will not
+     *                be shown in the Jenkins build console/log.
+     * @return        A {@link Result} that contains the execution details.
+     */
+    Result ignoreErrors(String cmd, Boolean silent)
+
+}

--- a/src/org/dsty/system/os/shell/package-info.groovy
+++ b/src/org/dsty/system/os/shell/package-info.groovy
@@ -1,0 +1,5 @@
+/**
+ * This package provides functionality for executing commands
+ * and scripts on various platforms.
+ */
+package org.dsty.system.os.shell

--- a/tests/test_system/test_os/test_shell/test_Bash.py
+++ b/tests/test_system/test_os/test_shell/test_Bash.py
@@ -2,7 +2,7 @@ from tests.conftest import Container
 
 def test_bash_example(container: Container):
 
-    job_output = container('bash/bash_example.groovy')
+    job_output = container('system/os/shell/bash_example.groovy')
 
     # Test regular bash
     assert "Hello from Bash!" in job_output
@@ -13,5 +13,5 @@ def test_bash_example(container: Container):
 
     # Test ignoreErrors bash
     assert "fakecommand: command not found" in job_output
-    assert "secretcommand" not in job_output
-    assert "anothercommand" not in job_output
+    assert "willNotRun" not in job_output
+    assert "commandWillRun" in job_output


### PR DESCRIPTION
Package `org.dsty.bash` has been marked deprecated and will be removed in `0.20.0`. 

The new `Bash` class is mostly compatible with the old one except for 2 minor changes. 

- The constructor no longer takes `this` aka the workflow script. It now takes 0 arguments.
- The failfast argument has been removed from method `ignoreErrors()`, it is now an instance property. 