### PR TITLE
Add Platform class to return information about the hardware/OS the current build is running on.

### DIFF
--- a/.groovylintrc.json
+++ b/.groovylintrc.json
@@ -1,6 +1,9 @@
 {
     "extends": "recommended",
     "rules": {
+        "BlockStartsWithBlankLine": {
+            "enabled": false
+        },
         "CompileStatic": {
             "enabled": false
         },

--- a/jobs/system/platform_example.groovy
+++ b/jobs/system/platform_example.groovy
@@ -1,0 +1,39 @@
+/* groovylint-disable DuplicateMapLiteral, DuplicateStringLiteral, UnnecessaryGetter, UnusedVariable */
+@Library('jenkins-std-lib')
+import org.dsty.system.Platform
+import org.dsty.system.os.shell.Shell
+
+node() {
+    // Ignore this line its for catching CPS issues.
+    String cps = sh(script: '#!/bin/bash\nset +x; > /dev/null 2>&1\necho Test for CPS issue', returnStdout: true)
+
+    // Get the current system type like WINDOWS or UNIX
+    String systemType = Platform.system()
+
+    List<String> validSystems = ['UNIX', 'WINDOWS', 'DARWIN']
+
+    // These tests are generic because I cant be certain where
+    // they will be run.
+    if (!validSystems.contains(systemType)) {
+        error("Should be a valid system but was ${systemType}")
+    }
+
+    // Get the current CPU architechture
+    String architecture = Platform.architecture()
+
+    List<String> validArchs = ['x86', 'x64', 'x86_x64', 'arm', 'arm64']
+
+    if (validArchs.contains(architecture)) {
+        error("Should be a valid architecture but was ${architecture}")
+    }
+
+    // Get a Shell for the current system
+    Shell shell = Platform.getShell()
+
+    // Make sure the shell works by writting a msg with it.
+    String msg = "Ran on ${architecture} ${systemType}"
+    shell("echo ${msg}")
+
+    // Ignore this line its for catching CPS issues.
+    cps = sh(script: '#!/bin/bash\nset +x; > /dev/null 2>&1\necho Test for CPS issue', returnStdout: true)
+}

--- a/src/org/dsty/jenkins/Build.groovy
+++ b/src/org/dsty/jenkins/Build.groovy
@@ -1,6 +1,8 @@
 /* groovylint-disable LineLength, UnnecessaryGetter */
 package org.dsty.jenkins
 
+import hudson.EnvVars
+
 /**
  * Returns the WorkFlowScript from the current build. This object has access
  * to pipeline steps like <code>sh()</code>, <code>checkout()</code> and
@@ -19,7 +21,17 @@ Object getWorkFlowScript() {
  * @return A Map of environment variables.
  */
 Map<String, String> environmentVars() {
-    return getContext(hudson.EnvVars)
+    return getEnvironment()
+}
+
+/**
+ * Returns the {@link EnvVars} for the current build.
+ *
+ * @return The {@link EnvVars} object.
+ * @see hudson.EnvVars
+ */
+EnvVars getEnvironment() {
+    return getCurrentContext(EnvVars)
 }
 
 /**

--- a/src/org/dsty/system/Platform.groovy
+++ b/src/org/dsty/system/Platform.groovy
@@ -1,0 +1,94 @@
+/* groovylint-disable ThrowException, UnnecessaryGetter */
+package org.dsty.system
+
+import org.dsty.system.os.shell.Bash
+import org.dsty.system.os.shell.Result
+import org.dsty.system.os.shell.Shell
+import org.dsty.jenkins.Build
+
+/**
+ * Provides information about the hardware and os the current
+ * build is running on.
+ */
+class Platform implements Serializable {
+
+    /**
+     * Sets the default {@link Shell} for the <code>UNIX</code> system.
+     */
+    static Class<Shell> unixShell = Bash
+
+    /**
+     * Sets the default {@link Shell} for the <code>WINDOWS</code> system.
+     */
+    static Class<Shell> winShell
+
+    /**
+     * Sets the default {@link Shell} for the <code>DARWIN</code> system.
+     */
+    static Class<Shell> darwinShell
+
+    /**
+     * Returns the system/OS name. The returned value will be one of <code>UNIX</code>,
+     * <code>DARWIN</code> or <code>WINDOWS</code>.
+     *
+     * @return The type of system the current build is running on.
+     */
+    static String system() {
+
+        Build build = new Build()
+
+        hudson.Platform platform = build.getEnvironment().getPlatform()
+
+        String currentPlatform = platform
+
+        if (platform == hudson.Platform.UNIX && platform.isDarwin()) {
+            currentPlatform = 'DARWIN'
+        }
+
+        return currentPlatform
+    }
+
+    /**
+     * Returns the architecture that is returned from
+     * <code>uname -m</code>.
+     *
+     * @return The architecture type.
+     * @see https://en.wikipedia.org/wiki/Uname
+     */
+    static String architecture() {
+
+        Shell shell = getShell()
+
+        Result result = shell.silent('uname -m')
+
+        return result.stdOut.trim()
+    }
+
+    /**
+     * Return a shell for the current {@link #system} type.
+     * <p>
+     * The default shell for each system can be set by modifying the fields
+     * {@link #unixShell}, {@link #winShell} and {@link #darwinShell}.
+     *
+     * @return A {@link Shell}.
+     */
+    static Shell getShell() {
+
+        String platform = system()
+
+        Map<String, Class<Shell>> shells = [
+            'UNIX': unixShell,
+            'WINDOWS': winShell,
+            'DARWIN': darwinShell
+        ]
+
+        Class<Shell> platformShell = shells[platform]
+
+        if (!platformShell) {
+            throw new Exception('UnsupportedPlatform')
+        }
+
+        return platformShell.newInstance()
+    }
+
+}

--- a/src/org/dsty/system/os/package-info.groovy
+++ b/src/org/dsty/system/os/package-info.groovy
@@ -1,6 +1,9 @@
 /**
  * This package provides operating system independent functionality.
  * <p>
- * If you want to work with files/directories see <a href="Path.html">Path</a>.
+ * If you want to work with files/directories see <a href="Path.html">Path</a>.</br>
+ * To install and run programs see <a href="../system/os/programs/package-summary.html">
+ * org.dsty.system.os.programs</a>.</br>
+ * To execute commands see <a href="../os/shell/package-summary.html">org.dsty.system.os.shell</a>.
  */
 package org.dsty.system.os

--- a/src/org/dsty/system/package-info.groovy
+++ b/src/org/dsty/system/package-info.groovy
@@ -1,6 +1,8 @@
 /**
- * This package provides operating system independent functionality.
+ * The packages under the <code>system</code> namespace provide information about the hardware
+ * and software the Jenkins build is being executed on.
  * <p>
- * If you want to work with files/directories see <a href="Path.html">Path</a>.
+ * To get information about the current <code>system</code> see <a href="Platform.html">Platform</a>.<br>
+ * To interact with programs and files see <a href="../system/os/package-summary.html">org.dsty.system.os</a>.
  */
 package org.dsty.system

--- a/tests/test_system/test_Platform.py
+++ b/tests/test_system/test_Platform.py
@@ -1,0 +1,13 @@
+import pytest
+
+from tests.conftest import Container
+
+@pytest.fixture()
+def job_folder():
+    return 'system'
+
+def test_platform_example(container: Container, job_folder):
+
+    job_output = container(f"{job_folder}/platform_example.groovy")
+
+    assert 'Ran on' in job_output


### PR DESCRIPTION
The `org.dsty.system.Platform` class returns information about the hardware and OS that the current build is running on.

You can find example usage in the [example job](https://github.com/DontShaveTheYak/jenkins-std-lib/blob/44f380f8a33cddc31b6a3cef9ae33678129945b8/jobs/system/platform_example.groovy).