### PR TITLE
Add System enum to give more detailed hardware/os information

### DIFF
--- a/jobs/system/distribution_example.groovy
+++ b/jobs/system/distribution_example.groovy
@@ -1,0 +1,25 @@
+/* groovylint-disable DuplicateMapLiteral, DuplicateStringLiteral, UnnecessaryGetter, UnusedVariable */
+@Library('jenkins-std-lib')
+import org.dsty.system.Platform
+import org.dsty.system.System
+
+node() {
+    // Ignore this line its for catching CPS issues.
+    sh(script: '#!/bin/bash\nset +x; > /dev/null 2>&1\necho Test for CPS issue', returnStdout: true)
+
+    // Get the current system type like WINDOWS or UNIX
+    System currentSystem = Platform.system()
+
+    List<String> validDistros = ['Ubuntu', 'CentOS', 'UNKNOWN']
+
+    String currentDistro = currentSystem.distribution()
+
+    if (!validDistros.contains(currentDistro)) {
+
+        error("Should be a valid distribution but was ${currentDistro}")
+
+    }
+
+    // Ignore this line its for catching CPS issues.
+    sh(script: '#!/bin/bash\nset +x; > /dev/null 2>&1\necho Test for CPS issue', returnStdout: true)
+}

--- a/jobs/system/platform_example.groovy
+++ b/jobs/system/platform_example.groovy
@@ -1,29 +1,30 @@
 /* groovylint-disable DuplicateMapLiteral, DuplicateStringLiteral, UnnecessaryGetter, UnusedVariable */
 @Library('jenkins-std-lib')
 import org.dsty.system.Platform
+import org.dsty.system.System
 import org.dsty.system.os.shell.Shell
 
 node() {
     // Ignore this line its for catching CPS issues.
-    String cps = sh(script: '#!/bin/bash\nset +x; > /dev/null 2>&1\necho Test for CPS issue', returnStdout: true)
+    sh(script: '#!/bin/bash\nset +x; > /dev/null 2>&1\necho Test for CPS issue', returnStdout: true)
 
     // Get the current system type like WINDOWS or UNIX
-    String systemType = Platform.system()
+    System currentSystem = Platform.system()
 
     List<String> validSystems = ['UNIX', 'WINDOWS', 'DARWIN']
 
     // These tests are generic because I cant be certain where
     // they will be run.
-    if (!validSystems.contains(systemType)) {
-        error("Should be a valid system but was ${systemType}")
+    if (!validSystems.contains(currentSystem.name())) {
+        error("Should be a valid system but was ${currentSystem}")
     }
 
     // Get the current CPU architechture
     String architecture = Platform.architecture()
 
-    List<String> validArchs = ['x86', 'x64', 'x86_x64', 'arm', 'arm64']
+    List<String> validArchs = ['x86', 'x64', 'amd64', 'arm', 'arm64']
 
-    if (validArchs.contains(architecture)) {
+    if (!validArchs.contains(architecture)) {
         error("Should be a valid architecture but was ${architecture}")
     }
 
@@ -31,9 +32,9 @@ node() {
     Shell shell = Platform.getShell()
 
     // Make sure the shell works by writting a msg with it.
-    String msg = "Ran on ${architecture} ${systemType}"
+    String msg = "Ran on ${architecture} ${currentSystem}"
     shell("echo ${msg}")
 
     // Ignore this line its for catching CPS issues.
-    cps = sh(script: '#!/bin/bash\nset +x; > /dev/null 2>&1\necho Test for CPS issue', returnStdout: true)
+    sh(script: '#!/bin/bash\nset +x; > /dev/null 2>&1\necho Test for CPS issue', returnStdout: true)
 }

--- a/src/org/dsty/system/Distribution.groovy
+++ b/src/org/dsty/system/Distribution.groovy
@@ -1,0 +1,61 @@
+/* groovylint-disable ThrowException, UnnecessaryGetter */
+package org.dsty.system
+
+import org.dsty.system.os.shell.Shell
+import org.dsty.system.os.shell.Result
+
+/**
+ * Provides information about the version of the current {@link System}.
+ */
+class Distribution {
+
+    /**
+     * Returns the name of the current {@link System System's} distribution.
+     * <p>
+     * Currently only {@link System#UNIX} is supported. The distribution is determined by
+     * <code>lsb_release -i</code>. If the {@link System} doesn't have <code>lsb_release</code>
+     * installed than <code>UNKNOWN</code> is returned.
+     *
+     * @param   system The current {@link System}.
+     * @return  The name of the current distribution or <code>UNKNOWN</code>.
+     */
+    static String name(System system) {
+
+        String dist
+
+        switch (system) {
+            case system.UNIX:
+                dist = unixDist(system)
+                break
+            default:
+                throw new Exception("Distribution name is not supported for ${system}.")
+        }
+
+        return dist
+    }
+
+    /**
+     * Get the distribution name for <code>UNIX</code> {@link System Systems}.
+     * <p>
+     * On <code>UNIX</code> {@link System Systems} this value comes from
+     * <code>lsb_release -i</code>.
+     *
+     * @param   system The current {@link System}.
+     * @return  The name of the current <code>UNIX</code> distribution or <code>UNKNOWN</code>.
+     */
+    private static String unixDist(System system) {
+
+        String distName = 'UNKNOWN'
+
+        Shell shell = system.getShell()
+
+        Result result = shell.ignoreErrors('lsb_release -i', true)
+
+        if (!result.exitCode) {
+            distName = result.stdOut.split()[-1]
+        }
+
+        return distName
+    }
+
+}

--- a/src/org/dsty/system/Platform.groovy
+++ b/src/org/dsty/system/Platform.groovy
@@ -2,7 +2,6 @@
 package org.dsty.system
 
 import org.dsty.system.os.shell.Bash
-import org.dsty.system.os.shell.Result
 import org.dsty.system.os.shell.Shell
 import org.dsty.jenkins.Build
 
@@ -28,12 +27,11 @@ class Platform implements Serializable {
     static Class<Shell> darwinShell
 
     /**
-     * Returns the system/OS name. The returned value will be one of <code>UNIX</code>,
-     * <code>DARWIN</code> or <code>WINDOWS</code>.
+     * Returns the {@link System} for the current agent.
      *
-     * @return The type of system the current build is running on.
+     * @return The {@link System}.
      */
-    static String system() {
+    static System system() {
 
         Build build = new Build()
 
@@ -45,23 +43,20 @@ class Platform implements Serializable {
             currentPlatform = 'DARWIN'
         }
 
-        return currentPlatform
+        return (currentPlatform as System)
     }
 
     /**
-     * Returns the architecture that is returned from
-     * <code>uname -m</code>.
+     * The architecture value that is returned by the
+     * <code>os.arch</code> java property.
      *
      * @return The architecture type.
-     * @see https://en.wikipedia.org/wiki/Uname
      */
     static String architecture() {
 
-        Shell shell = getShell()
+        final System currentSystem = system()
 
-        Result result = shell.silent('uname -m')
-
-        return result.stdOut.trim()
+        return currentSystem.architecture()
     }
 
     /**
@@ -74,21 +69,9 @@ class Platform implements Serializable {
      */
     static Shell getShell() {
 
-        String platform = system()
+        System currentSystem = system()
 
-        Map<String, Class<Shell>> shells = [
-            'UNIX': unixShell,
-            'WINDOWS': winShell,
-            'DARWIN': darwinShell
-        ]
-
-        Class<Shell> platformShell = shells[platform]
-
-        if (!platformShell) {
-            throw new Exception('UnsupportedPlatform')
-        }
-
-        return platformShell.newInstance()
+        return currentSystem.getShell()
     }
 
 }

--- a/src/org/dsty/system/System.groovy
+++ b/src/org/dsty/system/System.groovy
@@ -1,0 +1,74 @@
+/* groovylint-disable UnnecessaryPackageReference */
+package org.dsty.system
+
+import org.dsty.system.os.shell.Shell
+
+/**
+ * The type of agent the current build is running on.
+ */
+enum System {
+
+    /**
+     * A system derived from <code>UNIX</code>.
+     */
+    UNIX,
+
+    /**
+     * A system made by Microsoft.
+     */
+    WINDOWS,
+
+    /**
+     * A system made by Apple.
+     */
+    DARWIN
+
+    /**
+     * Gets the current {@link Shell} for the {@link System}.
+     * <p>
+     * Most {@link System Systems} can have more than one {@link Shell}. The default shell is
+     * determine by {@link Platform#unixShell}, {@link Platform#winShell} and {@link Platform#darwinShell}.
+     *
+     * @return  The {@link Shell} for the current {@link System}.
+     */
+    Shell getShell() {
+
+        Class<Shell> shell
+
+        switch (this) {
+            case UNIX:
+                shell = Platform.unixShell
+                break
+            case WINDOWS:
+                shell = Platform.winShell
+                break
+            case DARWIN:
+                shell = Platform.darwinShell
+                break
+        }
+
+        return shell.newInstance()
+    }
+
+    /**
+     * The name of the current {@link System System's} OS.
+     * <p>
+     * For {@link #UNIX} this might be <code>Ubuntu</code> or <code>CentOS</code>.
+     *
+     * @return  The name of the OS.
+     */
+    String distribution() {
+        return Distribution.name(this)
+    }
+
+    /**
+     * The architecture value that is returned by the
+     * <code>os.arch</code> java property.
+     *
+     * @return The architecture type.
+     */
+    String architecture() {
+        return java.lang.System.getProperty('os.arch')
+    }
+
+}


### PR DESCRIPTION
The `Platform` class now returns a `System` enum instead of a String like `UNIX` or `WINDOWS`. The `System` enum now provides things like the architecture, distribution name and shell.

I have updated the `Platform.architecture` and `Platform.getShell` methods to use the new `System` enum. There is still a lot of overlap between the two and I'm not sure what I will do in the future. It seems like right now, `Platform`'s only real use is to construct the `System` enum and to set the default shell. it is likely in the future I remove `Platform` and move it's responsibilities to `jenkins.Instance` or `jenkins.Build`.

Another change was instead of getting the architecture from `uname`, I'm getting it from java `os.arch` property.