### PR TITLE
Add programs package to install and run cli tools on Jenkins agents

### DIFF
--- a/jobs/system/os/programs/ScriptInstaller_example.groovy
+++ b/jobs/system/os/programs/ScriptInstaller_example.groovy
@@ -1,0 +1,167 @@
+// groovylint-disable-next-line
+/* groovylint-disable DuplicateMapLiteral, DuplicateStringLiteral, GetterMethodCouldBeProperty, ThrowException, UnnecessaryGetter, UnnecessarySubstring */
+@Library('jenkins-std-lib')
+import org.dsty.http.Requests
+import org.dsty.http.Response
+import org.dsty.system.System
+import org.dsty.system.Platform
+import org.dsty.system.os.Path
+import org.dsty.system.os.shell.Shell
+import org.dsty.system.os.programs.CliTool
+import org.dsty.system.os.programs.ScriptInstaller
+import org.dsty.system.os.download.HttpRetriever
+import org.dsty.system.os.download.FileRetriever
+
+/**
+ * Installs Act by downloading an install script from an HTTP url.
+ */
+class ActInstaller extends ScriptInstaller {
+
+    /**
+     * The version of act to install.
+     */
+    String version
+
+    /**
+     * The constructor takes a version parameter but we default to latest.
+     */
+    ActInstaller(String version = 'latest') {
+        this.version = version
+    }
+
+    /**
+     * This should be what we want to save the binary as.
+     */
+    String getBinName() {
+        return 'act'
+    }
+
+    /**
+     * This is only needed if our binary is in a subdirectory of
+     * a tar/zip. Since we are downloading the binary directly,
+     * we can just use the binary name.
+     */
+    String getBinPath() {
+        return getBinName()
+    }
+
+    /**
+     * This is the arguments to pass to the installer. The installer
+     * must allow you to set the path where the binary is installed and
+     * you must use installDir() for everything to work.
+     */
+    String getScriptArgs() {
+        return "-b ${installDir()} ${getVersion()}"
+    }
+
+    /**
+     * You can set the shell that you want to use when calling
+     * the install script. Here we are using the default shell,
+     * which is bash on unix systems.
+     */
+    Shell getShell() {
+        return Platform.getShell()
+    }
+
+    /**
+     * Set to true if the downloaded file will be a tar/zip.
+     */
+    Boolean isArchive() {
+        return false
+    }
+
+    /**
+     * How we want to retrieve the file. Currently only dirrectly via
+     * the HttpRetriever or via a tar/zip retrieved via HTTP with the ArchiveRetriever.
+     * <p>
+     * In the future I would like to support other retrievers like pip, npm and AWS S3.
+     */
+    Class<FileRetriever> getRetriever() {
+        return HttpRetriever
+    }
+
+    /**
+     * This function is needed to dynamicly change the version
+     * from latest to an actual version string.
+     */
+    String getVersion() {
+
+        if (this.@version == 'latest') {
+            this.version = latestVersion()
+        }
+
+        return this.@version
+    }
+
+    /**
+     * This sets the correct download url.
+     * <p>
+     * The System object is passed in which can provide the type of system
+     * and information about the hardware.
+     */
+    String downloadUrl(System system) { // groovylint-disable-line
+        return 'https://raw.githubusercontent.com/nektos/act/master/install.sh'
+    }
+
+    /**
+     * This function gets the latest version from the github release api.
+     */
+    String latestVersion() {
+        final String url = 'https://api.github.com/repos/nektos/act/releases/latest'
+
+        final Response response = Requests.get(url, headers: ['Accept': 'application/json'] )
+
+        final String releaseName = response.json['tag_name']
+
+        return releaseName
+    }
+
+}
+
+node() {
+
+    // Ignore the next line its for catching CPS issues.
+    sh(script: '#!/bin/bash\nset +x; > /dev/null 2>&1\necho Test for CPS issue', returnStdout: true)
+
+    // Clear the workspace
+    Path.workspace().deleteContents()
+
+    // The version we want to install
+    final String pinnedVersion = '0.2.22'
+
+    ActInstaller actInstaller = new ActInstaller("v${pinnedVersion}")
+
+    // Install the act binary and get back a generic cli tool
+    CliTool act = actInstaller.install()
+
+    // Get the version output for testing
+    String version = act.runCommand('--version').stdOut
+
+    // Test that the version is the one we pinned
+    if (!version.contains(pinnedVersion)) {
+
+        error("The version ${pinnedVersion} was not installed.")
+
+    }
+
+    // Does nothing since it is already installed
+    actInstaller.install()
+
+    // Install the latest version
+    actInstaller = new ActInstaller()
+
+    act = actInstaller.install()
+
+    version = act.runCommand('--version').stdOut
+
+    // Test the version installed is no longer the pinned version
+    if (version.contains(pinnedVersion)) {
+
+        error('The latest version was not installed.')
+
+    }
+
+    // Ignore the next line its for catching CPS issues.
+    sh(script: '#!/bin/bash\nset +x; > /dev/null 2>&1\necho Test for CPS issue', returnStdout: true)
+
+}

--- a/jobs/system/os/programs/UrlInstaller_example.groovy
+++ b/jobs/system/os/programs/UrlInstaller_example.groovy
@@ -1,0 +1,160 @@
+// groovylint-disable-next-line
+/* groovylint-disable DuplicateMapLiteral, DuplicateStringLiteral, GetterMethodCouldBeProperty, ThrowException, UnnecessaryGetter, UnnecessarySubstring */
+@Library('jenkins-std-lib')
+import org.dsty.http.Requests
+import org.dsty.http.Response
+import org.dsty.system.System
+import org.dsty.system.os.Path
+import org.dsty.system.os.programs.CliTool
+import org.dsty.system.os.programs.UrlInstaller
+import org.dsty.system.os.download.FileRetriever
+import org.dsty.system.os.download.ArchiveRetriever
+
+/**
+ * Installs Terraform by downloading the zip file from a HTTP url and
+ * then unpacking it.
+ */
+class TerraformInstaller extends UrlInstaller {
+
+    /**
+     * The version of terraform to install.
+     */
+    String version
+
+    /**
+     * The constructor takes a version parameter but we default to latest.
+     */
+    TerraformInstaller(String version = 'latest') {
+        this.version = version
+    }
+
+    /**
+     * This should be what we want to save the binary as.
+     */
+    String getBinName() {
+        return 'terraform'
+    }
+
+    /**
+     * This is only needed if our binary is in a subdirectory of
+     * a tar/zip. Since the binary is in the root of the zip file,
+     * we can just use the binary name.
+     */
+    String getBinPath() {
+        return getBinName()
+    }
+
+    /**
+     * How we want to retrieve the file. Currently only dirrectly via
+     * the HttpRetriever or via a tar/zip retrieved via HTTP with the ArchiveRetriever.
+     * <p>
+     * In the future I would like to support other retrievers like pip, npm and AWS S3.
+     */
+    Class<FileRetriever> getRetriever() {
+        return ArchiveRetriever
+    }
+
+    /**
+     * This function is needed to dynamicly change the version
+     * from latest to an actual version string.
+     */
+    String getVersion() {
+
+        if (this.@version == 'latest') {
+            this.version = latestVersion()
+        }
+
+        return this.@version
+    }
+
+    /**
+     * Set to true if the downloaded file will be a tar/zip.
+     */
+    Boolean isArchive() {
+        return true
+    }
+
+    /**
+     * This sets the correct download url.
+     * <p>
+     * The System object is passed in which can provide the type of system
+     * and information about the hardware.
+     */
+    String downloadUrl(System system) {
+
+        if (system.name() != 'UNIX') {
+            throw new Exception('Unsupported System.')
+        }
+
+        final String systemName = 'linux'
+        final String arch = system.architecture()
+
+        final String baseUrl = 'https://releases.hashicorp.com'
+
+        // https://releases.hashicorp.com/terraform/1.0.7/terraform_1.0.7_linux_amd64.zip
+        return "${baseUrl}/${getBinName()}/${getVersion()}/${getBinName()}_${getVersion()}_${systemName}_${arch}.zip"
+    }
+
+    /**
+     * This function gets the latest version from the github release api.
+     */
+    String latestVersion() {
+        final String url = 'https://api.github.com/repos/hashicorp/terraform/releases/latest'
+
+        final Response response = Requests.get(url, headers: ['Accept': 'application/json'] )
+
+        final String releaseName = response.json['tag_name']
+
+        // remove the v from the tag_name
+        return releaseName.substring(1)
+    }
+
+}
+
+node() {
+
+    // Ignore the next line its for catching CPS issues.
+    sh(script: '#!/bin/bash\nset +x; > /dev/null 2>&1\necho Test for CPS issue', returnStdout: true) // groovylint-disable-line
+
+    // Clear the workspace
+    Path.workspace().deleteContents()
+
+    // The version we want to install
+    final String pinnedVersion = '1.0.0'
+
+    TerraformInstaller tfInstaller = new TerraformInstaller(pinnedVersion)
+
+    // Install the terraform binary and get back a generic cli tool
+    CliTool terraform = tfInstaller.install()
+
+    // Get the version output for testing
+    String version = terraform.runCommand('--version').stdOut
+
+    // Test that the version is the one we pinned
+    if (!version.contains(pinnedVersion)) {
+
+        error("The version ${pinnedVersion} was not installed.")
+
+    }
+
+    // Does nothing since it is already installed
+    tfInstaller.install()
+
+    // Install the latest version
+    tfInstaller = new TerraformInstaller()
+
+    terraform = tfInstaller.install()
+
+    version = terraform.runCommand('--version').stdOut
+
+    // Test the version installed is no longer the pinned version
+    if (version.contains(pinnedVersion)) {
+
+        error('The latest version was not installed.')
+
+    }
+
+    // Ignore the next line its for catching CPS issues.
+    sh(script: '#!/bin/bash\nset +x; > /dev/null 2>&1\necho Test for CPS issue', returnStdout: true)
+
+}

--- a/src/org/dsty/jenkins/Instance.groovy
+++ b/src/org/dsty/jenkins/Instance.groovy
@@ -3,6 +3,7 @@ package org.dsty.jenkins
 
 import com.cloudbees.groovy.cps.NonCPS
 import jenkins.model.Jenkins
+import org.dsty.system.os.Path
 
 /**
  * This class represents the current Jenkins instance. It can be used to
@@ -35,6 +36,29 @@ class Instance implements Serializable {
     @NonCPS
     static List<String> plugins() {
         return Jenkins.instance.pluginManager.plugins*.getShortName()
+    }
+
+    /**
+     * Gets the {@link org.dsty.system.os.Path Path} to the directory where build tools are installed.
+     * <p>
+     * The directory can be configured with the environment variable <code>JSL_TOOLS_DIR</code>.
+     * This is useful to set the tool directory to someplace outside of the build workspace so that
+     * tools are cached between builds. This can also be set to a directory shared with multiple agents
+     * using a shared filesystem. This allows tools to be cached across multiple agents.
+     * <p>
+     * If the <code>JSL_TOOLS_DIR</code> envrionment variable is not set to a value then this
+     * method returns <code>null</code>.
+     *
+     * @return  The {@link org.dsty.system.os.Path Path} to the tool installation directory.
+     */
+    static Path toolsDir() {
+        Path toolDir
+
+        Map envVars = new Build().environmentVars()
+
+        toolDir = envVars.JSL_TOOLS_DIR ? Path(envVars.JSL_TOOLS_DIR) : null
+
+        return toolDir
     }
 
 }

--- a/src/org/dsty/system/Platform.groovy
+++ b/src/org/dsty/system/Platform.groovy
@@ -12,17 +12,17 @@ import org.dsty.jenkins.Build
 class Platform implements Serializable {
 
     /**
-     * Sets the default {@link Shell} for the <code>UNIX</code> system.
+     * Sets the default {@link org.dsty.system.os.shell.Shell} for the <code>UNIX</code> system.
      */
     static Class<Shell> unixShell = Bash
 
     /**
-     * Sets the default {@link Shell} for the <code>WINDOWS</code> system.
+     * Sets the default {@link org.dsty.system.os.shell.Shell} for the <code>WINDOWS</code> system.
      */
     static Class<Shell> winShell
 
     /**
-     * Sets the default {@link Shell} for the <code>DARWIN</code> system.
+     * Sets the default {@link org.dsty.system.os.shell.Shell} for the <code>DARWIN</code> system.
      */
     static Class<Shell> darwinShell
 
@@ -65,7 +65,7 @@ class Platform implements Serializable {
      * The default shell for each system can be set by modifying the fields
      * {@link #unixShell}, {@link #winShell} and {@link #darwinShell}.
      *
-     * @return A {@link Shell}.
+     * @return A {@link org.dsty.system.os.shell.Shell}.
      */
     static Shell getShell() {
 

--- a/src/org/dsty/system/System.groovy
+++ b/src/org/dsty/system/System.groovy
@@ -24,12 +24,13 @@ enum System {
     DARWIN
 
     /**
-     * Gets the current {@link Shell} for the {@link System}.
+     * Gets the current {@link org.dsty.system.os.shell.Shell} for the {@link System}.
      * <p>
-     * Most {@link System Systems} can have more than one {@link Shell}. The default shell is
-     * determine by {@link Platform#unixShell}, {@link Platform#winShell} and {@link Platform#darwinShell}.
+     * Most {@link System Systems} can have more than one {@link org.dsty.system.os.shell.Shell}.
+     * The default shell is determine by {@link Platform#unixShell}, {@link Platform#winShell}
+     * and {@link Platform#darwinShell}.
      *
-     * @return  The {@link Shell} for the current {@link System}.
+     * @return  The {@link org.dsty.system.os.shell.Shell} for the current {@link System}.
      */
     Shell getShell() {
 

--- a/src/org/dsty/system/os/programs/AbstractExecutable.groovy
+++ b/src/org/dsty/system/os/programs/AbstractExecutable.groovy
@@ -1,0 +1,48 @@
+/* groovylint-disable DuplicateNumberLiteral, UnnecessaryGetter */
+package org.dsty.system.os.programs
+
+import org.dsty.system.os.Path
+
+/**
+ * The base class for all {@link Executable Executables}.
+ */
+abstract class AbstractExecutable implements Serializable, Executable {
+
+    /**
+     * The path to the executable file.
+     */
+    final protected Path filePath
+
+    /**
+     * The default constructor.
+     *
+     * @param filePath The path to the executable on the disk.
+     */
+    protected AbstractExecutable(Path filePath) {
+        this.filePath = filePath
+    }
+
+    /**
+     * Gets the absolute path to the executable.
+     */
+    String getPath() {
+        return filePath.absolutize()
+    }
+
+    /**
+     * Checks if the executable can be executed on the current platform.
+     *
+     * @return <code>true</code> if the file can be executed on the current platform,
+               otherwise <code>false</code>.
+     */
+    abstract Boolean isExecutable()
+
+    /**
+     * Make the file executable.
+     * <p>
+     * On <code>UNIX</code> this means making sure the user has execute permissions and
+     * on <code>WINDOWS</code> this means making sure the file has the correct extension.
+     */
+    abstract void setExecutePermission()
+
+}

--- a/src/org/dsty/system/os/programs/AbstractToolInstaller.groovy
+++ b/src/org/dsty/system/os/programs/AbstractToolInstaller.groovy
@@ -1,0 +1,178 @@
+/* groovylint-disable UnnecessaryGetter */
+package org.dsty.system.os.programs
+
+import org.dsty.jenkins.Instance
+
+import org.dsty.system.os.Path
+import org.dsty.system.Platform
+import org.dsty.system.System
+import org.dsty.system.os.programs.ToolBuilder
+import org.dsty.system.os.shell.Shell
+
+/**
+ * The base class for all {@link ToolInstaller ToolInstaller's} that install {@link CliTool CliTool's} to the system.
+ */
+abstract class AbstractToolInstaller implements Serializable, ToolInstaller {
+
+    /**
+     * Return the name of the binary, which is typically the name of the tool.
+     * <p>
+     * For a tool like Terraform the name would be <code>terraform</code>. This name
+     * is used to identify this tool when logging to the console. It's also used in
+     * the installation path.
+     *
+     * @see     #installDir()
+     * @return  The name of the binary which is often the tool name.
+     */
+    abstract String getBinName()
+
+    /**
+     * This is the path to the executable inside of it's installation medium.
+     * <p>
+     * When installing a executable directly, then this is typically just the
+     * {@link #getBinName()}. When installing from a zip file, where the executable
+     * is inside a subdir called <code>my_custom_bin</code> then {@link #getBinPath()}
+     * should return <code>"my_custom_bin/${getBinName()}"</code>.
+     *
+     * @see     #installPath()
+     * @return  The path to the executable, relative to the {@link #installDir()}
+     */
+    abstract String getBinPath()
+
+    /**
+     * The version of the executable that is being installed.
+     * <p>
+     * The version is used in the installation path. If the executable does not have
+     * a version then return something like <code>0.0.0</code> or <code>latest</code>.
+     *
+     * @see     #installPath()
+     * @return  An identifer marking the version of the executable.
+     */
+    abstract String getVersion()
+
+    /**
+     * This method when called will install the executable to the system and then return a
+     * {@link CliTool} that is ready to execute commands.
+     * <p>
+     * It's recommened that you check if the executable is already installed first by using {@link #isInstalled()}
+     * first.
+     *
+     * @see     #getTool()
+     * @return  A {@link CliTool} that is ready to execute commands.
+     */
+    abstract CliTool install()
+
+    /**
+     * Checks to see if the executable is already installed on the system.
+     *
+     * @see     #installPath()
+     * @return  <code>true</code> if the executable is already present, otherwise <code>false</code>.
+     */
+    Boolean isInstalled() {
+
+        Path tool = installPath()
+
+        return tool.exists()
+    }
+
+    /**
+     * Returns the default {@link org.dsty.system.os.shell.Shell} for the given platform.
+     * <p>
+     * This method should be overidden if the {@link CliTool} you are implementing is only applicable to
+     * a certain platform, like <code>WINDOWS</code>.
+     *
+     * @see     org.dsty.system.Platform#getShell()
+     * @return  The {@link org.dsty.system.os.shell.Shell} that will be used when creating the {@link CliTool}.
+     */
+    protected Shell getShell() {
+        return Platform.getShell()
+    }
+
+    /**
+     * Sets the type of tool to use.
+     * <p>
+     * You will most likely want to override this method to a custom implementation.
+     *
+     * @return  The class {@link CliTool}.
+     */
+    protected Class<CliTool> useTool() {
+        return CliTool
+    }
+
+    /**
+     * Gets the {@link CliTool} from the {@link ToolBuilder}.
+     * <p>
+     * This should be called at the end of {@link #install()}.
+     *
+     * @see     #install()
+     * @return  A {@link CliTool} that has been {@link #install() installed} and ready to use.
+     */
+    protected CliTool getTool() {
+        return ToolBuilder.buildTool(this)
+    }
+
+    /**
+     * Get the current {@link org.dsty.system.System}.
+     *
+     * @return  The {@link org.dsty.system.System} instance.
+     */
+    protected System getSystem() {
+
+        return Platform.system()
+
+    }
+
+    /**
+     * The {@link org.dsty.system.os.Path Path} to the installed {@link Executable}.
+     * <p>
+     * The {@link org.dsty.system.os.Path Path} is created by combining the output from
+     * {@link #installDir()} and {@link #getBinPath()}.
+     *
+     * @return  The {@link org.dsty.system.os.Path Path} to the installed {@link Executable}.
+     */
+    protected Path installPath() {
+
+        return installDir().child(getBinPath())
+    }
+
+    /**
+     * The {@link org.dsty.system.os.Path Path} to the directory where the {@link Executable} will
+     * be installed.
+     * <p>
+     * The {@link org.dsty.system.os.Path Path} is created by getting the {@link #toolsDir()} and then
+     * appending the {@link #getBinName()} and the {@link #getVersion()}.
+     *
+     * @return  The {@link org.dsty.system.os.Path Path} to the directory where the {@link Executable} will
+     *          be installed.
+     */
+    protected Path installDir() {
+
+        Path toolDir = toolsDir().child("${getBinName()}/${getVersion()}")
+        toolDir.mkdirs()
+
+        return toolDir
+    }
+
+    /**
+     * The {@link org.dsty.system.os.Path Path} to the tool installation directory.
+     * <p>
+     * By default this is the <code>.tools</code> directory inside of the builds workspace
+     * but can also be set to a specific directory using the <code>JSL_TOOLS_DIR</code>
+     * environment variable.
+     *
+     * @see     org.dsty.jenkins.Instance#toolsDir()
+     * @return  The {@link org.dsty.system.os.Path Path} to the tool installation directory.
+     */
+    protected Path toolsDir() {
+
+        Path installDir = Instance.toolsDir()
+
+        if (!installDir) {
+            installDir = Path.workspace().child('.tools')
+            installDir.mkdirs()
+        }
+
+        return installDir
+    }
+
+}

--- a/src/org/dsty/system/os/programs/CliTool.groovy
+++ b/src/org/dsty/system/os/programs/CliTool.groovy
@@ -1,0 +1,98 @@
+/* groovylint-disable UnnecessaryGetter */
+package org.dsty.system.os.programs
+
+import org.dsty.system.os.shell.Shell
+import org.dsty.system.os.shell.Result
+import org.dsty.system.os.shell.ExecutionException
+
+/**
+ * A {@link CliTool} is the combination of a {@link org.dsty.system.os.shell.Shell} and a {@link Executable}.
+ * <p>
+ * This class is just a base class that is capable of running a command as an example.
+ * It is expected that this class is extended and additional methods are created to run
+ * commands specific to the {@link Executable} you are using.
+ */
+class CliTool implements Serializable {
+
+    protected Shell shell
+    protected Executable bin
+
+    /**
+     * Creates a {@link CliTool} from a {@link org.dsty.system.os.shell.Shell} and a {@link Executable}.
+     * <p>
+     * The {@link Executable} must exist and be executable.
+     *
+     * @param shell  The {@link org.dsty.system.os.shell.Shell} to use when executing commands.
+     * @param bin    The {@link Executable} to use when executing commands.
+     */
+    CliTool(Shell shell, Executable bin) {
+        this.shell = shell
+        this.bin = bin
+    }
+
+    /**
+     * The path to the {@link Executable}.
+     * <p>
+     * This path is wrapped in single quotes to avoid errors when
+     * files or directories have spaces in there names.
+     *
+     * @return  The path to the {@link Executable}.
+     */
+    protected String binPath() {
+
+        return "'${bin.getPath()}'"
+
+    }
+
+    /**
+     * Runs a command using the path to the {@link Executable} and the given
+     * <code>args</code>.
+     * <p>
+     * The output from this command will be visible in the build console.
+     *
+     * @param args  The arguments to pass to the {@link Executable}.
+     * @return      A {@link org.dsty.system.os.shell.Result shell.Result}.
+     */
+    protected Result runCommand(String args) {
+
+        return shell.call("${binPath()} ${args}")
+
+    }
+
+    /**
+     * Runs a command silently using the path to the {@link Executable} and the given
+     * <code>args</code>.
+     * <p>
+     * The output from this command will not be visible in the build console.
+     *
+     * @param args  The arguments to pass to the {@link Executable}.
+     * @return      A {@link org.dsty.system.os.shell.Result shell.Result}.
+     */
+    protected Result runCommandSilent(String args) {
+
+        return shell.silent("${binPath()} ${args}")
+
+    }
+
+    /**
+     * Runs a command using the path to the {@link Executable} and the given
+     * <code>args</code>.
+     * <p>
+     * If the command fails the {@link org.dsty.system.os.shell.Result shell.Result}
+     * is returned instead of throwing {@link ExecutionException}.
+     * <p>
+     * The output from this command will be visible in the build console but can be turned
+     * off by setting <code>silent</code> to <code>true</code>.
+     *
+     * @param args    The arguments to pass to the {@link Executable}.
+     * @param silent  Set to <code>true</code> to run the command silently, defaults to
+                      <code>false</code>.
+     * @return        A {@link org.dsty.system.os.shell.Result shell.Result}.
+     */
+    protected Result runCommandIgnoreErrors(String args, Boolean silent = false) {
+
+        return shell.ignoreErrors("${binPath()} ${args}", silent)
+
+    }
+
+}

--- a/src/org/dsty/system/os/programs/Executable.groovy
+++ b/src/org/dsty/system/os/programs/Executable.groovy
@@ -1,0 +1,29 @@
+package org.dsty.system.os.programs
+
+/**
+ * A file that can be executed using a {@link org.dsty.system.os.shell.Shell}.
+ */
+interface Executable {
+
+    /**
+     * Checks if the executable can be executed on the current platform.
+     *
+     * @return <code>true</code> if the file can be executed on the current platform,
+               otherwise <code>false</code>.
+     */
+    Boolean isExecutable()
+
+    /**
+     * Make the file executable.
+     * <p>
+     * On <code>UNIX</code> this means making sure the user has execute permissions and
+     * on <code>WINDOWS</code> this means making sure the file has the correct extension.
+     */
+    void setExecutePermission()
+
+    /**
+     * Gets the absolute path to the executable.
+     */
+    String getPath()
+
+}

--- a/src/org/dsty/system/os/programs/ExecutableBuilder.groovy
+++ b/src/org/dsty/system/os/programs/ExecutableBuilder.groovy
@@ -1,0 +1,46 @@
+/* groovylint-disable ThrowException */
+package org.dsty.system.os.programs
+
+import java.nio.file.NoSuchFileException
+
+import org.dsty.system.os.Path
+import org.dsty.system.Platform
+import org.dsty.system.System
+import org.dsty.system.os.programs.UnixExecutable
+
+/**
+ * Creates {@link Executable Executables} for the current system.
+ */
+class ExecutableBuilder {
+
+    /**
+     * Returns an {@link Executable} for the current system.
+     * <p>
+     * Currently only <code>UNIX</code> is supported. If method
+     * is called on any other system then <code>UnsupportedSystemException</code>
+     * exception is thrown.
+     *
+     * @throws  NoSuchFileException If the <code>filePath</code> does not exist.
+     * @param   filePath The {@link Path} to the executable file.
+     * @return  A {@link Executable} that has the correct execution permissions.
+     */
+    static Executable buildExecutable(Path filePath) throws NoSuchFileException {
+
+        if (!filePath.exists()) {
+            throw new NoSuchFileException(filePath.absolutize())
+        }
+
+        final System os = Platform.system()
+
+        if (os.value() != 'UNIX') {
+            throw new Exception('UnsupportedSystemException')
+        }
+
+        Executable bin = new UnixExecutable(filePath)
+
+        bin.setExecutePermission()
+
+        return bin
+    }
+
+}

--- a/src/org/dsty/system/os/programs/ExecutableBuilder.groovy
+++ b/src/org/dsty/system/os/programs/ExecutableBuilder.groovy
@@ -32,7 +32,7 @@ class ExecutableBuilder {
 
         final System os = Platform.system()
 
-        if (os.value() != 'UNIX') {
+        if (os.name() != 'UNIX') {
             throw new Exception('UnsupportedSystemException')
         }
 

--- a/src/org/dsty/system/os/programs/ScriptInstaller.groovy
+++ b/src/org/dsty/system/os/programs/ScriptInstaller.groovy
@@ -1,0 +1,70 @@
+/* groovylint-disable UnnecessaryGetter */
+package org.dsty.system.os.programs
+
+import org.dsty.system.os.Path
+import org.dsty.system.os.shell.Shell
+
+/**
+ * A {@link ToolInstaller} that uses an install script to install
+ * a {@link CliTool} to the system.
+ */
+abstract class ScriptInstaller extends UrlInstaller {
+
+    /**
+     * This is the path to the install script returned by the
+     * {@link org.dsty.system.os.download.FileRetriever FileRetriever}.
+     * <p>
+     * When installing a executable directly, then this is typically just the
+     * name of the file. When installing from a zip file, where the executable
+     * is inside a subdir called <code>my_custom_bin</code> then {@link #getScriptPath()}
+     * should return <code>"my_custom_bin/my_script_name"</code>.
+     * <p>
+     * By default this method returns <code>"${getBinName()}_installer"</code> but should be
+     * overriden if {@link #downloadUrl(String, String) downloadUrl} will point to a zip/tar file.
+     *
+     * @return  The path to the install script, relative to the {@link #installDir()}.
+     */
+    String getScriptPath() {
+        return "${getBinName()}_installer"
+    }
+
+    /**
+     * The arguments to pass to the install script.
+     * <p>
+     * For the install to work correctly the install script must take an argument to choose
+     * the install directory and you must pass the {@link #installDir()} to it.
+     *
+     * @return  The arguments to pass to the install script located at {@link #getScriptPath()}.
+     */
+    abstract String getScriptArgs()
+
+    /**
+     * Installs the {@link CliTool} to the system.
+     * <p>
+     * When called this will first check if the tool is installed using {@link #isInstalled()}
+     * and if not then it will call {@link #download()} to get the install script from the
+     * {@link #downloadUrl()} using the {@link org.dsty.system.os.download.FileRetriever FileRetriever}
+     * specified by {@link #getRetriever()}. It will then execute the install script with the
+     * args from {@link #getScriptArgs()}.
+     * <p>
+     * The {@link CliTool} is then created using {@link #getTool()}.
+     *
+     * @return A {@link CliTool} that is ready to run commands on the system.
+     */
+    CliTool install() {
+
+        if (!isInstalled()) {
+
+            Path script = isArchive() ? download() : download(getScriptPath())
+
+            Executable installer = ExecutableBuilder.buildExecutable(script)
+
+            Shell shell = getShell()
+
+            shell.call("${installer.getPath()} ${getScriptArgs()}")
+        }
+
+        return getTool()
+    }
+
+}

--- a/src/org/dsty/system/os/programs/ToolBuilder.groovy
+++ b/src/org/dsty/system/os/programs/ToolBuilder.groovy
@@ -1,0 +1,68 @@
+/* groovylint-disable DuplicateStringLiteral, ThrowException, UnnecessaryGetter */
+package org.dsty.system.os.programs
+
+import java.lang.reflect.Constructor
+
+import org.dsty.system.os.Path
+import org.dsty.system.Platform
+import org.dsty.system.System
+import org.dsty.system.os.shell.Shell
+
+/**
+ * Creates {@link CliTool CliTool's} for the current system.
+ */
+class ToolBuilder {
+
+    /**
+     * Returns an executable for the current system.
+     * <p>
+     * Currently only <code>UNIX</code> is supported. If method
+     * is called on any other system then <code>UnsupportedSystemException</code>
+     * exception is thrown.
+     */
+    static CliTool buildTool(Path filePath) {
+        final System os = Platform.system()
+
+        if (os.name() != 'UNIX') {
+            throw new Exception('UnsupportedSystemException')
+        }
+
+        Executable bin = ExecutableBuilder.buildExecutable(filePath)
+
+        return buildTool(bin)
+    }
+
+    /**
+     * Returns an executable for the current system.
+     * <p>
+     * Currently only <code>UNIX</code> is supported. If method
+     * is called on any other system then <code>UnsupportedSystemException</code>
+     * exception is thrown.
+     */
+    static CliTool buildTool(Executable executable) {
+        final System os = Platform.system()
+
+        if (os.name() != 'UNIX') {
+            throw new Exception('UnsupportedSystemException')
+        }
+
+        Shell shell = Platform.getShell()
+
+        return new CliTool(shell, executable)
+    }
+
+    static CliTool buildTool(ToolInstaller installer) {
+
+        Executable executable = ExecutableBuilder.buildExecutable(installer.installPath())
+
+        Class<CliTool> toolClass = installer.useTool()
+
+        Constructor toolCon = toolClass.getConstructor(Shell, Executable)
+
+        CliTool tool = toolCon.newInstance(installer.getShell(), executable)
+
+        return tool
+
+    }
+
+}

--- a/src/org/dsty/system/os/programs/ToolInstaller.groovy
+++ b/src/org/dsty/system/os/programs/ToolInstaller.groovy
@@ -1,0 +1,19 @@
+package org.dsty.system.os.programs
+
+/**
+ * A ToolInstaller installs {@link CliTool CliTool's} into the workspace from
+ * a variety of sources.
+ */
+interface ToolInstaller {
+
+    /**
+     * Installs a {@link CliTool} into the current build's workspace in the <code>.tools</code>
+     * directory. The install location can be changed to enable tool caching using the
+     * environment variable <code>JSL_TOOLS_DIR</code>.
+     *
+     * @return A {@link CliTool} that is ready to run commands.
+     * @see org.dsty.jenkins.Instance#toolsDir()
+     */
+    CliTool install()
+
+}

--- a/src/org/dsty/system/os/programs/UnixExecutable.groovy
+++ b/src/org/dsty/system/os/programs/UnixExecutable.groovy
@@ -4,7 +4,7 @@ package org.dsty.system.os.programs
 import org.dsty.system.os.Path
 
 /**
- * A {@link Executable} that be run on <code>UNIX</code> systems.
+ * A {@link Executable} that can be run on <code>UNIX</code> systems.
  */
 class UnixExecutable extends AbstractExecutable {
 

--- a/src/org/dsty/system/os/programs/UnixExecutable.groovy
+++ b/src/org/dsty/system/os/programs/UnixExecutable.groovy
@@ -1,0 +1,64 @@
+/* groovylint-disable DuplicateNumberLiteral, UnnecessaryGetter */
+package org.dsty.system.os.programs
+
+import org.dsty.system.os.Path
+
+/**
+ * A {@link Executable} that be run on <code>UNIX</code> systems.
+ */
+class UnixExecutable extends AbstractExecutable {
+
+    /**
+     * The default constructor.
+     *
+     * @param filePath  The {@link Path} to the executable file.
+     */
+    protected UnixExecutable(Path filePath) {
+        super(filePath)
+    }
+
+    /**
+     * Checks if the group permission is executable.
+     *
+     * @return <code>true</code> if the group has execute permission, otherwise <code>false</code>
+     */
+    Boolean isExecutable() {
+        // Need to convert from octal to a string and then to a int
+        final String octal = Integer.toOctalString(filePath.mode())
+        final int mode = Integer.parseInt(octal)
+
+        // Get the hundredths value
+        final int userPermission = (mode / 100).intValue() % 10
+
+        // Checks if the first bit is a 0 or 1
+        // all odd numbers start with a 1
+        // an odd number 1,3,5 and 7 means execute permissions
+        final Boolean isOdd = (userPermission & 1) == 1
+
+        return isOdd
+    }
+
+    /**
+     * Makes the file executable by giving group permission to execute.
+     * <p>
+     * This method will check if the file {@link #isExecutable()} first.
+     */
+    void setExecutePermission() {
+
+        if (isExecutable()) {
+            return
+        }
+
+        // Get the String octal
+        final String octal = Integer.toOctalString(filePath.mode())
+
+        // Convert to int and add 100 to make it executable
+        final int newMode = Integer.parseInt(octal) + 100
+
+        // Take the octal string and convert back to int
+        final int mode = Integer.parseInt("0${newMode}", 8)
+
+        filePath.chmod(mode)
+    }
+
+}

--- a/src/org/dsty/system/os/programs/UrlInstaller.groovy
+++ b/src/org/dsty/system/os/programs/UrlInstaller.groovy
@@ -1,0 +1,161 @@
+/* groovylint-disable UnnecessaryGetter */
+package org.dsty.system.os.programs
+
+import org.dsty.system.os.Path
+import org.dsty.system.os.download.FileRetriever
+import org.dsty.system.System
+
+/**
+ * A {@link ToolInstaller} that uses a {@link org.dsty.system.os.download.FileRetriever FileRetriever}
+ * to install a {@link CliTool} to the system.
+ */
+abstract class UrlInstaller extends AbstractToolInstaller {
+
+    /**
+     * If the file returned by the {@link org.dsty.system.os.download.FileRetriever FileRetriever}
+     * will be a zip or tar file then set this to <code>true</code>.
+     *
+     * @see     #downloadPath()
+     * @return  <code>true</code> if the file is a zip/tar file, otherwise <code>false</code>.
+     */
+    abstract Boolean isArchive()
+
+    /**
+     * This specifies the type of {@link org.dsty.system.os.download.FileRetriever FileRetriever} you want to use.
+     *
+     * @return A class that implements the {@link org.dsty.system.os.download.FileRetriever FileRetriever} interface.
+     */
+    abstract Class<FileRetriever> getRetriever()
+
+    /**
+     * This returns the download url for your {@link Executable}.
+     * <p>
+     * This url should point to a file that can be downloaded to install your {@link CliTool}. The type of file
+     * will depend on your {@link org.dsty.system.os.download.FileRetriever FileRetriever}
+     * specified by {@link #getRetriever()}.
+     * <p>
+     * Often the download URL will depend on the type of system and it's architecture. The
+     * {@link org.dsty.system.System} will be passed in to provide that information.
+     *
+     * @param system  A {@link org.dsty.system.System} which provides the type of system and other
+     *                information like the architecture.
+     * @return        The url to download the file/files needed to install the {@link CliTool}
+     */
+    abstract String downloadUrl(System system)
+
+    /**
+     * Installs the {@link CliTool} to the system.
+     * <p>
+     * When called this will first check if the tool is installed using {@link #isInstalled()}
+     * and if not then it will call {@link #download()} to get the {@link Executable} from the
+     * {@link #downloadUrl()} using the {@link org.dsty.system.os.download.FileRetriever FileRetriever}
+     * specified by {@link #getRetriever()}.
+     * <p>
+     * The {@link CliTool} is then created using {@link #getTool()}.
+     *
+     * @return A {@link CliTool} that is ready to run commands on the system.
+     */
+    CliTool install() {
+
+        if (!isInstalled()) {
+            download()
+        }
+
+        return getTool()
+    }
+
+    /**
+     * Create the {@link org.dsty.system.System} object and uses it to call
+     * {@link #downloadUrl()}.
+     *
+     * @return The url to download the file/files needed to install the {@link CliTool}.
+     */
+    protected String getDownloadUrl() {
+
+        final System system = getSystem()
+        return downloadUrl(system)
+    }
+
+    /**
+     * The {@link org.dsty.system.os.Path Path} that is passed to
+     * {@link #download()} when {@link #install()} is called.
+     * <p>
+     * If the {@link org.dsty.system.os.download.FileRetriever FileRetriever} {@link #isArchive()} then
+     * {@link installDir()} is returned so the contents of the archive can be unpacked, otherwise
+     * {@link installPath()} is returned.
+     *
+     * @return  If {@link #isArchive()} then {@link installDir()}, otherwise {@link installPath()}.
+     */
+    protected Path downloadPath() {
+
+        Path destination = isArchive() ? installDir() : installPath()
+
+        return destination
+    }
+
+    /**
+     * Downloads the file/files from {@link #getDownloadUrl()}.
+     * <p>
+     * The file/files is downloaded to {@link #downloadPath()} using the
+     * {@link org.dsty.system.os.download.FileRetriever FileRetriever} from {@link #getRetriever()}.
+     *
+     * @return The {@link org.dsty.system.os.Path Path} from {@link downloadPath()}.
+     */
+    protected Path download() {
+
+        final Path destination = downloadPath()
+
+        return retrieve(destination)
+    }
+
+    /**
+     * Downloads the file/files from {@link #getDownloadUrl()}.
+     * <p>
+     * The file/files is downloaded to a path inside of {@link #installDir()}. This method
+     * is useful for installing additional files for the {@link CliTool} like config files.
+     *
+     * @param childPath  A path that will be combined with {@link #installDir()} to create
+     *                   the download location.
+     * @return           The {@link org.dsty.system.os.Path} to the downloaded file/files.
+     */
+    protected Path download(String childPath) {
+
+        final Path destination = installDir().child(childPath)
+
+        return retrieve(destination)
+    }
+
+    /**
+     * Downloads the file/files from {@link #getDownloadUrl()} using the
+     * {@link org.dsty.system.os.download.FileRetriever FileRetriever} from {@link #getRetriever()}.
+     *
+     * @param destination  The {@link org.dsty.system.os.Path} to where the file/files will be downloaded.
+     * @return             The parameter <code>destination</code> is returned.
+     */
+    protected Path retrieve(final Path destination) {
+
+        final String url = getDownloadUrl()
+
+        final FileRetriever source = getFileRetriever()
+
+        source.retrieve(url, destination)
+
+        return destination
+
+    }
+
+    /**
+     * Creates an instance of {@link org.dsty.system.os.download.FileRetriever}
+     * specifed by {@link #getRetriever()}.
+     *
+     * @return  A instance of {@link org.dsty.system.os.download.FileRetriever}.
+     */
+    protected FileRetriever getFileRetriever() {
+
+        Class<FileRetriever> retriever = getRetriever()
+
+        return retriever.newInstance()
+
+    }
+
+}

--- a/src/org/dsty/system/os/programs/package-info.groovy
+++ b/src/org/dsty/system/os/programs/package-info.groovy
@@ -1,0 +1,4 @@
+/**
+ * Install and run applications like CLI tools.
+ */
+package org.dsty.system.os.programs

--- a/tests/test_system/test_os/test_programs/test_ToolInstaller.py
+++ b/tests/test_system/test_os/test_programs/test_ToolInstaller.py
@@ -1,0 +1,25 @@
+import pytest
+
+from tests.conftest import Container
+
+@pytest.fixture()
+def job_folder():
+    return 'system/os/programs'
+
+def test_script_installer(container: Container, job_folder):
+
+    job_output = container(f"{job_folder}/ScriptInstaller_example.groovy")
+
+    install_msg = 'checking GitHub'
+
+    # Test that the tool was installed twice
+    assert job_output.count(install_msg) == 2
+
+def test_url_installer(container: Container, job_folder):
+
+    job_output = container(f"{job_folder}/UrlInstaller_example.groovy")
+
+    install_msg = 'Extracting to'
+
+    # Test that the tool was installed twice
+    assert job_output.count(install_msg) == 2


### PR DESCRIPTION
The `programs` package is accessible to the public for **advanced** users but is primary intended for use internally by other parts of the library. 

The package was designed with cross platform capability in mind but as of right now is only setup for linux. The package makes it really easy to install and manage tools on the Jenkins agent.

This is a stepping stone to providing more advanced features now that we can easily install tools like Terraform, AWS CLI and others!