### PR TITLE
Change docker containers to not require the docker socket from the host

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,9 +26,6 @@
 	// Put the workspace in the jenkins home directory so it can be installed into the jenkins as a shared library.
 	"workspaceMount": "source=${localWorkspaceFolder},target=/var/jenkins_home/pipeline-library,type=bind,consistency=cached",
 	"workspaceFolder": "/var/jenkins_home/pipeline-library",
-	"containerEnv": {
-		"DIND_WORKSPACE": "${localWorkspaceFolder}"
-	},
 	// Set the build args
 	// "build": {
 	// 	"args": {
@@ -46,15 +43,13 @@
 		"5050:80"
 	],
 	// Uncomment the next line to run commands after the container is created - for example installing curl.
-	"postStartCommand": "nohup /usr/local/bin/jenkins.sh & ./gradlew downloadJars",
+	"postStartCommand": "./gradlew downloadJars",
 	// "postCreateCommand": "/sbin/tini -- /usr/local/bin/jenkins.sh &",
 	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
-	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+	// "runArgs": [ "--cap-add=NET_ADMIN", "--init"],
 	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
-	"mounts": [
-		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
-	],
 	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "jenkins",
-	"runArgs": ["--init"]
+	"containerUser": "root",
+	"runArgs": [ "--privileged"]
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,12 @@ on:
       - 'docker/**'
 
 jobs:
+  debug:
+    name: Debug docker
+    runs-on: ubuntu-latest
+    steps:
+      - run: docker info
+
   linting:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,6 @@ on:
       - 'docker/**'
 
 jobs:
-  debug:
-    name: Debug docker
-    runs-on: ubuntu-latest
-    steps:
-      - run: docker info
-
   linting:
     name: Lint
     runs-on: ubuntu-latest

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,7 @@
     "editor.tabSize": 4,
     "editor.insertSpaces": true,
     "editor.detectIndentation": false
-  }
+  },
+  "python.formatting.provider": "black",
+  "editor.formatOnSave": true
 }

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -7,25 +7,25 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 USER root
 
+ARG USERNAME=jenkins
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Ensure apt is in non-interactive to avoid prompts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# # Create the user
+RUN apt-get update \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
 RUN apt-get update && \
     apt-get install -y \
-        sudo \
         python3 \
         python3-pip && \
     python3 -m pip install --upgrade pip && \
     rm -rf /var/lib/apt/lists/*
-
-RUN echo "#!/bin/sh\n\
-    sudoIf() { if [ \"\$(id -u)\" -ne 0 ]; then sudo \"\$@\"; else \"\$@\"; fi }\n\
-    SOCKET_GID=\$(stat -c '%g' /var/run/docker.sock) \n\
-    if [ \"${SOCKET_GID}\" != '0' ]; then\n\
-        if [ \"\$(cat /etc/group | grep :\${SOCKET_GID}:)\" = '' ]; then sudoIf groupadd --gid \${SOCKET_GID} docker-host; fi \n\
-        if [ \"\$(id ${NONROOT_USER} | grep -E \"groups=.*(=|,)\${SOCKET_GID}\(\")\" = '' ]; then sudoIf usermod -aG \${SOCKET_GID} ${NONROOT_USER}; fi\n\
-    fi\n\
-    exec \"\$@\"" > /usr/local/share/docker-init.sh \
-    && chmod +x /usr/local/share/docker-init.sh \
-    && echo $NONROOT_USER ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$NONROOT_USER \
-    && chmod 0440 /etc/sudoers.d/$NONROOT_USER
 
 USER jenkins
 WORKDIR $JENKINS_HOME
@@ -43,7 +43,4 @@ COPY docker/dev/init_scripts/* /usr/share/jenkins/ref/init.groovy.d/
 ENV JAVA_OPTS -Djenkins.install.runSetupWizard=false
 ENV JENKINS_SLAVE_AGENT_PORT=
 ENV JENKINS_OPTS="--httpPort=80"
-ENV PATH="/$JENKINS_HOME/.local/bin:$PATH"
-
-ENTRYPOINT [ "/usr/local/share/docker-init.sh" ]
-CMD [ "sleep", "infinity" ]
+ENV PATH="$JENKINS_HOME/.local/bin:$PATH"

--- a/docker/jfr/Dockerfile
+++ b/docker/jfr/Dockerfile
@@ -14,5 +14,6 @@ RUN cd /usr/share/jenkins && jar -xvf jenkins.war
 RUN rm /etc/s6-overlay/s6-rc.d/user/contents.d/jenkins
 
 COPY /docker/jfr/run_job.sh /usr/bin/run_job
+COPY docker/jfr/root /
 
 ENV JENKINS_HOME="/usr/share/jenkins/ref/"

--- a/docker/jfr/Dockerfile
+++ b/docker/jfr/Dockerfile
@@ -10,11 +10,9 @@ USER root
 
 RUN cd /usr/share/jenkins && jar -xvf jenkins.war
 
+# We dont font need to run the Jenkins GUI in the JFR
+RUN rm /etc/s6-overlay/s6-rc.d/user/contents.d/jenkins
+
+COPY /docker/jfr/run_job.sh /usr/bin/run_job
+
 ENV JENKINS_HOME="/usr/share/jenkins/ref/"
-ENV JAVA_OPTS="-Djenkins.model.Jenkins.slaveAgentPort=50000 -Djenkins.model.Jenkins.slaveAgentPortEnforce=true -Dhudson.model.LoadStatistics.clock=1000"
-
-USER jenkins
-
-ENTRYPOINT ["/app/bin/jenkinsfile-runner", "-w", "/usr/share/jenkins/", "-p", "/usr/share/jenkins/ref/plugins", "--withInitHooks", "/usr/share/jenkins/ref/init.groovy.d/", "-f"]
-
-CMD ["/workspace/Jenkinsfile"]

--- a/docker/jfr/root/etc/docker/daemon.json
+++ b/docker/jfr/root/etc/docker/daemon.json
@@ -1,0 +1,3 @@
+{
+    "storage-driver": "vfs"
+}

--- a/docker/jfr/run_job.sh
+++ b/docker/jfr/run_job.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+JOB=$1
+
+/app/bin/jenkinsfile-runner run -w /usr/share/jenkins \
+    --withInitHooks /usr/share/jenkins/ref/init.groovy.d \
+    -p /usr/share/jenkins/ref/plugins \
+    --runWorkspace /var/jenkins_home/workspace/job \
+    -f "/workspace/${JOB}"

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -1,4 +1,9 @@
-FROM jenkins/jenkins:latest-jdk11
+FROM docker.io/jenkins/jenkins:2.346.3-lts-jdk11
+
+ARG USERNAME=jenkins
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+ARG S6_OVERLAY_VERSION=3.1.2.1
 
 USER root
 
@@ -6,6 +11,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y \
+        xz-utils \
+        kmod \
         wget \
         git \
         curl && \
@@ -14,6 +21,26 @@ RUN apt-get update && \
 # Install and setup docker into the container
 RUN curl -fsSL https://get.docker.com -o get-docker.sh && \
     sh get-docker.sh
+
+# This crazy stuff was needed to make docker work indepently inside the running container
+# but also work with non root user like Jenkins... has to be a cleaner way tbh.
+RUN wget -P /usr/bin/ https://raw.githubusercontent.com/docker-library/docker/master/dockerd-entrypoint.sh && \
+    wget -P /usr/bin/ https://raw.githubusercontent.com/docker-library/docker/master/docker-entrypoint.sh && \
+    chmod +x /usr/bin/dockerd-entrypoint.sh && \
+    chmod +x /usr/bin/docker-entrypoint.sh && \
+    mkdir -p /run/user/$USER_UID && \
+    chown ${USER_GID}:${USER_GID} /run/user/$USER_UID && \
+    update-alternatives --set iptables /usr/sbin/iptables-legacy && \
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy && \
+    touch /var/run/docker.sock && \
+    chown root:docker /var/run/docker.sock && \
+    chmod 660 /var/run/docker.sock && \
+    usermod -aG docker $USERNAME
+
+ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz /tmp
+RUN tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz
+ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-x86_64.tar.xz /tmp
+RUN tar -C / -Jxpf /tmp/s6-overlay-x86_64.tar.xz
 
 USER jenkins
 
@@ -33,3 +60,8 @@ ENV JENKINS_SLAVE_AGENT_PORT=
 ENV JENKINS_OPTS="--httpPort=80"
 
 EXPOSE 80
+
+USER root
+COPY docker/prod/root /
+
+ENTRYPOINT ["/init"]

--- a/docker/prod/root/etc/s6-overlay/s6-rc.d/dockerd/run
+++ b/docker/prod/root/etc/s6-overlay/s6-rc.d/dockerd/run
@@ -1,0 +1,3 @@
+#!/command/with-contenv bash
+
+exec /usr/bin/dockerd-entrypoint.sh

--- a/docker/prod/root/etc/s6-overlay/s6-rc.d/dockerd/type
+++ b/docker/prod/root/etc/s6-overlay/s6-rc.d/dockerd/type
@@ -1,0 +1,1 @@
+longrun

--- a/docker/prod/root/etc/s6-overlay/s6-rc.d/jenkins/run
+++ b/docker/prod/root/etc/s6-overlay/s6-rc.d/jenkins/run
@@ -1,0 +1,3 @@
+#!/command/with-contenv bash
+
+exec su jenkins -c "bash /usr/local/bin/jenkins.sh"

--- a/docker/prod/root/etc/s6-overlay/s6-rc.d/jenkins/type
+++ b/docker/prod/root/etc/s6-overlay/s6-rc.d/jenkins/type
@@ -1,0 +1,1 @@
+longrun

--- a/jobs/github/actions/step_example.groovy
+++ b/jobs/github/actions/step_example.groovy
@@ -4,10 +4,6 @@
 import org.dsty.github.actions.Step
 
 node() {
-    // This is needed if you run jenkins in a docker container.
-    // It's the path on the host machine where your docker bind mount is stored.
-    // docker run -v '/tmp/jenkins_home:/var/run/jenkins_home' jenkins/jenkins:lts
-    env.DIND_JENKINS_HOME = '/tmp/jenkins_home'
 
     String cps = sh(script: '#!/bin/bash\nset +x; > /dev/null 2>&1\necho Test for CPS issue', returnStdout: true)
 
@@ -36,7 +32,7 @@ node() {
     stage('JavaScript Action') {
         options = [
             'name': 'Test JavaScript Action',
-            'uses': 'actions/hello-world-javascript-action@master',
+            'uses': 'actions/hello-world-javascript-action@main',
             'with': [
                 'who-to-greet': 'JavaScriptAction'
             ]

--- a/src/org/dsty/github/actions/ActionFactory.groovy
+++ b/src/org/dsty/github/actions/ActionFactory.groovy
@@ -52,7 +52,8 @@ class ActionFactory implements Serializable {
                 break
         }
 
-        if (actionType == 'node12') {
+        // Stupid workaround that will be fixed later
+        if (actionType == 'node16') {
             action = new JavaScriptAction(this.steps)
         }
 

--- a/src/org/dsty/github/actions/JavaScriptAction.groovy
+++ b/src/org/dsty/github/actions/JavaScriptAction.groovy
@@ -27,15 +27,10 @@ class JavaScriptAction extends DockerAction implements GithubAction {
         String actionDir = '/github/action'
         String workspace = "${this.options.workspace}/${this.name}"
 
-        if (this.steps.env.DIND_JENKINS_HOME) {
-            List parts = this.options.workspace.split('/workspace/')
-
-            workspace = "${this.steps.env.DIND_JENKINS_HOME}/workspace/${parts[1]}/${this.name}"
-        }
-
         this.metadata.runs.entrypoint = 'node'
-        this.metadata.runs.args = ["${actionDir}/${this.metadata.runs.main}"
-    ]
+        this.metadata.runs.args = [
+            "${actionDir}/${this.metadata.runs.main}"
+        ]
         this.metadata.runs['pre-entrypoint'] = this.metadata.runs.pre ?: ''
         this.metadata.runs['post-entrypoint'] = this.metadata.runs.post ?: ''
 
@@ -44,43 +39,13 @@ class JavaScriptAction extends DockerAction implements GithubAction {
         this.log.info(this.log.pprint(this.options))
         this.log.info(this.log.pprint(this.metadata))
 
-        Map outputs = this.actionRun('node:12.20.1-buster-slim')
+        String nodeVersion = this.metadata.runs.using
+
+        Number version = nodeVersion.find( /\d+/ ).toInteger()
+
+        Map outputs = this.actionRun("node:${version}")
 
         return outputs
-    }
-
-    /**
-     * Parses the input for Github Actions outputs.
-     * @param input to search for Github Actions outputs.
-     * @returns the outputs found.
-     */
-    @NonCPS
-    @Override
-    Map parseOutputs(String input) {
-        Map outputs = [:]
-
-        List matches = (input =~ /(?m)##\[set-output.*$/).findAll()
-
-        for (match in matches) {
-            String outputName = (match =~ /(?m)(?<=name=).*(?=;])/).findAll().first()
-            String outputValue = (match =~ /(?m);](.*$)/).findAll().first()[1]
-
-            outputs[outputName] = outputValue
-        }
-
-        return outputs
-    }
-
-    /**
-     * Removes the Github Actions outputs so it can be displayed
-     * to the user.
-     * @param input to search for Github Actions outputs.
-     * @returns the input free of any Github Action outputs.
-     */
-    @NonCPS
-    @Override
-    String cleanOutput(String input) {
-        return (input =~ /(?m)##\[set-output.*$/).replaceAll('')
     }
 
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,18 +2,21 @@ import os
 from pathlib import Path
 from typing import Callable, Generator, Optional
 import shutil
+from time import sleep
 
 import docker
 import pytest
 
 Container = Callable[[str], str]
 
-@pytest.fixture(scope='session')
+
+@pytest.fixture(scope="session")
 def client():
     return docker.from_env()
 
-@pytest.fixture(scope='session')
-def container(client: docker.DockerClient)-> Generator[Container, None, None]:
+
+@pytest.fixture(scope="session")
+def container(client: docker.DockerClient) -> Generator[Container, None, None]:
     """Creates a jenkinsfile runner container and then Yields a function that
     can run jenkins jobs on the already started container.
 
@@ -24,41 +27,45 @@ def container(client: docker.DockerClient)-> Generator[Container, None, None]:
         Generator[Callable[[str], str], None, None]: A function that will run Jenkins jobs.
     """
 
-    jobs_path: str = str(Path(__file__, '../../jobs').resolve())
-    lib_path: str = str(Path(__file__, '../../').resolve())
-    tmp_home: str = '/tmp/jenkins_home'
+    jobs_path: str = str(Path(__file__, "../../jobs").resolve())
+    lib_path: str = str(Path(__file__, "../../").resolve())
+    # tmp_home: str = '/tmp/jenkins_home'
 
-    (baseImage, _ ) = client.images.build(path=lib_path, dockerfile='docker/prod/Dockerfile', tag='jsl_prod', rm=True)
+    (baseImage, _) = client.images.build(
+        path=lib_path, dockerfile="docker/prod/Dockerfile", tag="jsl_prod", rm=True
+    )
 
-    (image, _ ) = client.images.build(path=lib_path, dockerfile='docker/jfr/Dockerfile', tag='jsl_jfr', buildargs={'baseImage': baseImage.id}, rm=True)
-
-    shutil.rmtree(tmp_home, ignore_errors=True)
-    shutil.copytree(lib_path, f"{tmp_home}/pipeline-library", dirs_exist_ok=True,)
-
-    dind_path: Optional[str] = os.getenv('DIND_WORKSPACE')
-
-    if dind_path:
-        jobs_path = f"{dind_path}/jobs"
-        lib_path = dind_path
+    (image, _) = client.images.build(
+        path=lib_path,
+        dockerfile="docker/jfr/Dockerfile",
+        tag="jsl_jfr",
+        buildargs={"baseImage": baseImage.id},
+        rm=True,
+    )
 
     volumes = {
-        jobs_path: {
-            'bind': '/workspace',
-            'mode': 'ro'
-        },
-        tmp_home: {
-            'bind': '/var/jenkins_home',
-            'mode': 'rw'
-        },
-        '/var/run/docker.sock': {
-            'bind': '/var/run/docker.sock',
-            'mode': 'rw'
-        }
+        jobs_path: {"bind": "/workspace", "mode": "ro"},
+        lib_path: {"bind": "/var/jenkins_home/pipeline-library", "mode": "rw"},
     }
 
-    container = client.containers.run(image.id,tty=True, entrypoint='bash',detach=True, volumes=volumes)
+    # Check to see if we are in the VSCODE dev container
+    if "REMOTE_CONTAINERS" in os.environ:
 
-    def run_test(job_path: str)-> str:
+        # In the devcontainer we are safe to mount the docker image cache
+        # to speed up the testing of jobs.
+        volumes["/tmp/docker_cache"] = {
+            "bind": "/var/lib/docker",
+            "mode": "rw",
+        }
+
+    container = client.containers.run(
+        image.id, tty=True, detach=True, volumes=volumes, privileged=True
+    )
+
+    # We should really do some kinda check to see if docker daemon is up and running =/
+    sleep(30)
+
+    def run_test(job_path: str) -> str:
         """Runs the specified job using the jenkins runner.
 
         Args:
@@ -73,17 +80,11 @@ def container(client: docker.DockerClient)-> Generator[Container, None, None]:
         exitcode: int
         raw_output: bytes
 
-        cmd = (
-            "/app/bin/jenkinsfile-runner -w /usr/share/jenkins "
-            "--withInitHooks /usr/share/jenkins/ref/init.groovy.d "
-            "-p /usr/share/jenkins/ref/plugins "
-            "--runWorkspace /var/jenkins_home/workspace/job "
-            f"-f /workspace/{job_path}"
-        )
+        cmd = f"run_job {job_path}"
 
-        exitcode, raw_output = container.exec_run(cmd, user='root')
+        exitcode, raw_output = container.exec_run(cmd, user="root")
 
-        output = raw_output.decode('utf-8')
+        output = raw_output.decode("utf-8")
 
         if exitcode:
             print(output)

--- a/tests/test_scm/test_Generic.py
+++ b/tests/test_scm/test_Generic.py
@@ -2,14 +2,21 @@ import pytest
 
 from tests.conftest import Container
 
+
 @pytest.fixture()
 def job_folder():
-    return 'scm'
+    return "scm"
+
 
 def test_generic_unit(container: Container, job_folder):
 
     container(f"{job_folder}/tests/test_generic.groovy")
 
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Broken because of https://issues.jenkins.io/browse/JENKINS-70025",
+)
 def test_generic_example(container: Container, job_folder):
 
     job_output = container(f"{job_folder}/generic_example.groovy")

--- a/tests/test_scm/test_Generic.py
+++ b/tests/test_scm/test_Generic.py
@@ -14,8 +14,7 @@ def test_generic_unit(container: Container, job_folder):
 
 
 @pytest.mark.xfail(
-    strict=True,
-    reason="Broken because of https://issues.jenkins.io/browse/JENKINS-70025",
+    reason="Sometimes fails because of https://issues.jenkins.io/browse/JENKINS-70025",
 )
 def test_generic_example(container: Container, job_folder):
 


### PR DESCRIPTION
Previously the Docker containers would require the passing of the host machine's docker socket to work correctly. This caused a ton of issues because the Jenkins container would often have its workspaces in a bind mount. That meant that you couldn't pass in the jobs workspace in Jenkins to a child container with out knowing the full path to the workspace. This was a total pain. 

This PR changes the containers so that they use the s6 overlay to run both Docker daemon and Jenkins. They now run a complete docker inside the containers. The major downside is that Docker requires that the containers are run with the `--privledge` flag to make the docker daemon work correctly. Also CICD tests can be a lot slower since there is not cache sharing from the host machine too the devcontainer and then to the JFR.

Overall I'm pretty happy with this change.