### PR TITLE
Fix HTTP request crash when the response does not contain a `Content-Type` header.

### DIFF
--- a/src/org/dsty/http/Requests.groovy
+++ b/src/org/dsty/http/Requests.groovy
@@ -153,7 +153,7 @@ class Requests implements Serializable {
 
         Response response = handleRequest(connection)
 
-        if (response.headers?.'Content-Type'.contains('application/json')) {
+        if (response.headers?.'Content-Type'?.contains('application/json') == true) {
             JsonSlurperClassic slurper = new JsonSlurperClassic()
             response.json = slurper.parseText(response.body)
         }


### PR DESCRIPTION
Fixes: https://github.com/DontShaveTheYak/jenkins-std-lib/issues/305